### PR TITLE
chore: Update UgcPoiController and UgcTrackController oc: 4247

### DIFF
--- a/app/Http/Controllers/UgcPoiController.php
+++ b/app/Http/Controllers/UgcPoiController.php
@@ -8,6 +8,7 @@ use App\Models\UgcMedia;
 use App\Models\UgcPoi;
 use App\Providers\HoquServiceProvider;
 use App\Traits\UGCFeatureCollectionTrait;
+use App\Traits\ValidationTrait;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
@@ -17,7 +18,7 @@ use Illuminate\Support\Facades\Log;
 
 class UgcPoiController extends Controller
 {
-    use UGCFeatureCollectionTrait;
+    use UGCFeatureCollectionTrait, ValidationTrait;
     /**
      * Display a listing of the resource.
      *
@@ -64,11 +65,35 @@ class UgcPoiController extends Controller
      *
      * @return Response
      */
+    public function store(Request $request, $version = 'v1'): Response
+    {
+
+        Log::channel('ugc')->info("*************store ugc poi*****************");
+        $data = $request->all();
+        $dataProperties = $data['properties'];
+        Log::channel('ugc')->info('ugc poi store properties name:' . $dataProperties['name']);
+        Log::channel('ugc')->info('ugc poi store properties app_id(sku):' . $dataProperties['app_id']);
+
+        switch ($version) {
+            case 'v1':
+            default:
+                return $this->storeV1($request);
+            case 'v2':
+                return $this->storeV2($request);
+        }
+    }
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
     public function storeV1(Request $request): Response
     {
         Log::channel('ugc')->info('api version V1');
         $data = $request->all();
-        $validator = Validator::make($data, [
+        $this->checkValidation($data, [
             'type' => 'required',
             'properties' => 'required|array',
             'properties.name' => 'required|max:255',
@@ -77,11 +102,6 @@ class UgcPoiController extends Controller
             'geometry.type' => 'required',
             'geometry.coordinates' => 'required|array',
         ]);
-
-        if ($validator->fails()) {
-            Log::channel('ugc')->info('Validazione fallita:', $validator->errors()->toArray());
-            return response(['error' => $validator->errors(), 'Validation Error'], 400);
-        }
 
         $user = auth('api')->user();
         Log::channel('ugc')->info('user email:' . $user->email);
@@ -140,6 +160,7 @@ class UgcPoiController extends Controller
         $poi->raw_data = json_encode($data['properties']);
         $poi->save();
         $poi->populateProperties();
+        $poi->populatePropertyForm('poi_acquisition_form');
 
         $hoquService = app(HoquServiceProvider::class);
         try {
@@ -148,30 +169,81 @@ class UgcPoiController extends Controller
         }
         return response(['id' => $poi->id, 'message' => 'Created successfully'], 201);
     }
-    public function storeV2(Request $request): Response {}
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param Request $request
-     *
-     * @return Response
-     */
-    public function store(Request $request, $version = 'v1'): Response
-    {
-
-        Log::channel('ugc')->info("*************store ugc poi*****************");
+    public function storeV2(Request $request): Response {
+        $user = auth('api')->user();
         $data = $request->all();
-        $dataProperties = $data['properties'];
-        Log::channel('ugc')->info('ugc poi store properties name:' . $dataProperties['name']);
-        Log::channel('ugc')->info('ugc poi store properties app_id(sku):' . $dataProperties['app_id']);
+        Log::channel('ugc')->info("*************store v2 ugc poi*****************");
+        Log::channel('ugc')->info('user email:' . $user->email);
+        Log::channel('ugc')->info('user id:' . $user->id);
+        $properties = $data['properties'];
+        Log::channel('ugc')->info('ugc poi store properties name:' . $properties['name']);
+        Log::channel('ugc')->info('ugc poi store properties app_id:' . $properties['app_id']);
 
-        switch ($version) {
-            case 'v1':
-            default:
-                return $this->storeV1($request);
-            case 'v2':
-                return $this->storeV2($request);
+        $this->checkValidation($data, [
+            'type' => 'required',
+            'properties' => 'required|array',
+            'properties.name' => 'required|max:255',
+            'properties.app_id' => 'required|max:255',
+            'geometry' => 'required|array',
+            'geometry.type' => 'required',
+            'geometry.coordinates' => 'required|array',
+        ]);
+
+        $user = auth('api')->user();
+        Log::channel('ugc')->info('user email:' . $user->email);
+        Log::channel('ugc')->info('user id:' . $user->id);
+        if (is_null($user)) {
+            Log::channel('ugc')->info('Utente non autenticato');
+            return response(['error' => 'User not authenticated'], 403);
         }
+
+
+        $poi = new UgcPoi();
+        $poi->name = $properties['name'];
+        $poi->geometry = DB::raw("ST_GeomFromGeojson('" . json_encode($data['geometry']) . ")')");
+        $poi->properties = $properties;
+        $poi->user_id = $user->id;
+
+        if (isset($data['properties']['app_id'])) {
+            $app_id = $data['properties']['app_id'];
+            if (is_numeric($app_id)) {
+                Log::channel('ugc')->info('numeric');
+                $app = App::where('id', '=', $app_id)->first();
+                if ($app != null) {
+                    $poi->app_id = $app_id;
+                    $poi->sku = $app->sku;
+                }
+            } else {
+                Log::channel('ugc')->info('sku');
+                $app = App::where('sku', '=', $app_id)->first();
+                if ($app != null) {
+                    $poi->app_id = $app->id;
+                    $poi->sku = $app_id;
+                }
+            }
+        }
+
+        try {
+            $poi->save();
+        } catch (\Exception $e) {
+            Log::channel('ugc')->info('Errore nel salvataggio del poi:' . $e->getMessage());
+            return response(['error' => 'Error saving POI'], 500);
+        }
+
+        if (isset($properties['image_gallery']) && is_array($properties['image_gallery']) && count($properties['image_gallery']) > 0) {
+            foreach ($properties['image_gallery'] as $imageId) {
+                if (!!UgcMedia::find($imageId))
+                    $poi->ugc_media()->attach($imageId);
+            }
+        }
+        $poi->save();
+
+        $hoquService = app(HoquServiceProvider::class);
+        try {
+            $hoquService->store('update_ugc_taxonomy_wheres', ['id' => $poi->id, 'type' => 'poi']);
+        } catch (\Exception $e) {
+        }
+        return response(['id' => $poi->id, 'message' => 'Created successfully'], 201);
     }
 
     /**

--- a/app/Http/Controllers/UgcTrackController.php
+++ b/app/Http/Controllers/UgcTrackController.php
@@ -15,10 +15,11 @@ use App\Http\Resources\UgcTrackCollection;
 use App\Traits\UGCFeatureCollectionTrait;
 use Exception;
 use Illuminate\Support\Facades\Log;
+use App\Traits\ValidationTrait;
 
 class UgcTrackController extends Controller
 {
-    use UGCFeatureCollectionTrait;
+    use UGCFeatureCollectionTrait, ValidationTrait;
     /**
      * Display a listing of the resource.
      *
@@ -67,14 +68,26 @@ class UgcTrackController extends Controller
      *
      * @return Response
      */
-    public function store(Request $request): Response
+    public function store(Request $request, $version = 'v1'): Response
+    {
+        Log::channel('ugc')->info("*************store ugc track*****************");
+        Log::channel('ugc')->info('version:' . $version);
+        switch ($version) {
+            case 'v1':
+            default:
+                return $this->storeV1($request);
+            case 'v2':
+                return $this->storeV2($request);
+        }
+    }
+    public function storeV1(Request $request): Response
     {
         $data = $request->all();
-        Log::channel('ugc')->info("*************store ugc track*****************");
+        Log::channel('ugc')->info("*************store v1 ugc track*****************");
         $dataProperties = $data['properties'];
         Log::channel('ugc')->info('ugc poi store properties name:' . $dataProperties['name']);
         Log::channel('ugc')->info('ugc poi store properties app_id(sku):' . $dataProperties['app_id']);
-        $validator = Validator::make($data, [
+        $this->checkValidation($data, [
             'type' => 'required',
             'properties' => 'required|array',
             'properties.name' => 'required|max:255',
@@ -83,11 +96,6 @@ class UgcTrackController extends Controller
             'geometry.type' => 'required',
             'geometry.coordinates' => 'required|array',
         ]);
-
-        if ($validator->fails()) {
-            Log::channel('ugc')->info('Validazione fallita:', $validator->errors()->toArray());
-            return response(['error' => $validator->errors(), 'Validation Error']);
-        }
 
         $user = auth('api')->user();
         if (is_null($user))
@@ -144,6 +152,82 @@ class UgcTrackController extends Controller
         $track->raw_data = json_encode($data['properties']);
         $track->save();
         $track->populateProperties();
+        $track->populatePropertyForm('track_acquisition_form');
+
+        $hoquService = app(HoquServiceProvider::class);
+        try {
+            $hoquService->store('update_ugc_taxonomy_wheres', ['id' => $track->id, 'type' => 'track']);
+        } catch (\Exception $e) {
+        }
+
+        return response(['id' => $track->id, 'message' => 'Created successfully'], 201);
+    }
+    public function storeV2(Request $request): Response
+    {
+        $user = auth('api')->user();
+        $data = $request->all();
+        Log::channel('ugc')->info("*************store v2 ugc track*****************");
+        Log::channel('ugc')->info('user email:' . $user->email);
+        Log::channel('ugc')->info('user id:' . $user->id);
+        $properties = $data['properties'];
+        Log::channel('ugc')->info('ugc poi store properties name:' . $properties['name']);
+        Log::channel('ugc')->info('ugc poi store properties app_id:' . $properties['app_id']);
+        $this->checkValidation($data, [
+            'type' => 'required',
+            'properties' => 'required|array',
+            'properties.name' => 'required|max:255',
+            'properties.app_id' => 'required|max:255',
+            'geometry' => 'required|array',
+            'geometry.type' => 'required',
+            'geometry.coordinates' => 'required|array',
+        ]);
+
+        $user = auth('api')->user();
+        if (is_null($user))
+            return response(['error' => 'User not authenticated'], 403);
+
+        $track = new UgcTrack();
+
+        $track->name = $properties['name'];
+        $track->geometry = DB::raw("ST_Force3D(ST_GeomFromGeojson('" . json_encode($data['geometry']) . "'))");
+        $track->properties = $properties;
+        $track->user_id = $user->id;
+
+        if (isset($properties['app_id'])) {
+            $app_id = $properties['app_id'];
+            if (is_numeric($app_id)) {
+                Log::channel('ugc')->info('numeric');
+                $app = App::where('id', '=', $app_id)->first();
+                if ($app != null) {
+                    $track->app_id = $app_id;
+                    $track->sku = $app->sku;
+                }
+            } else {
+                Log::channel('ugc')->info('sku');
+                $app = App::where('sku', '=', $app_id)->first();
+                if ($app != null) {
+                    $track->app_id = $app->id;
+                    $track->sku = $app_id;
+                }
+            }
+        }
+
+        try {
+            $track->save();
+        } catch (\Exception $e) {
+            Log::channel('ugc')->info('Errore nel salvataggio della track:' . $e->getMessage());
+            return response(['error' => 'Error saving Track'], 500);
+        }
+
+        if (isset($properties['image_gallery']) && is_array($properties['image_gallery']) && count($properties['image_gallery']) > 0) {
+            foreach ($properties['image_gallery'] as $imageId) {
+                if (!!UgcMedia::find($imageId))
+                    $track->ugc_media()->attach($imageId);
+            }
+        }
+
+        unset($properties['image_gallery']);
+        $track->save();
 
         $hoquService = app(HoquServiceProvider::class);
         try {

--- a/app/Traits/ValidationTrait.php
+++ b/app/Traits/ValidationTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Validator;
+
+trait ValidationTrait
+{
+    protected function checkValidation($data, $rules)
+    {
+        $validator = Validator::make($data, $rules);
+
+        if ($validator->fails()) {
+            $currentErrors = json_decode($validator->errors(), true);
+            $errors = [];
+            foreach ($currentErrors as $key => $error) {
+                $errors[$key] = $error;
+            }
+
+            return response(['error' => $errors], 400);
+        }
+    }
+} 

--- a/routes/api.php
+++ b/routes/api.php
@@ -80,7 +80,7 @@ Route::name('api.')->group(function () {
                 Route::get("delete/{id}", [UgcPoiController::class, 'destroy'])->name('destroy');
             });
             Route::prefix('track')->name('track.')->group(function () {
-                Route::post("store", [UgcTrackController::class, 'store'])->name('store');
+                Route::post("store/{version?}", [UgcTrackController::class, 'store'])->name('store');
                 Route::get("index/{version?}", [UgcTrackController::class, 'index'])->name('index');
                 Route::get("delete/{id}", [UgcTrackController::class, 'destroy'])->name('destroy');
             });


### PR DESCRIPTION
- Added ValidationTrait to UgcPoiController and UgcTrackController
- Refactored store method in UgcPoiController to support multiple versions
- Added storeV1 and storeV2 methods in UgcPoiController for different versions
- Removed validation logic from store method in UgcPoiController
- Refactored store method in UgcTrackController to support multiple versions
- Added storeV1 and storeV2 methods in UgcTrackController for different versions

chore: Refactor UgcMediaController

- Remove unused import statements
- Move the ValidationTrait to be used in the UgcMediaController
- Remove redundant code for populating properties and checking validation

chore: Add ValidationTrait for handling data validation

This commit adds a new file `ValidationTrait.php` under the `app/Traits` directory. The trait provides a method `checkValidation()` that takes in data and rules, and uses Laravel's Validator to validate the data against the given rules. If validation fails, it returns a response with the corresponding errors.

chore: Update UgcTrackController store route to include optional version parameter

The UgcTrackController store route in the api.php file has been updated to include an optional "version" parameter. This allows for more flexibility when storing track data.
