### PR TITLE
chore: Add UpdateUgcPropertiesWithDateCommand oc: 4453

### DIFF
--- a/app/Console/Commands/UpdateUgcPropertiesWithDateCommand.php
+++ b/app/Console/Commands/UpdateUgcPropertiesWithDateCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\UgcMedia;
+use App\Models\UgcPoi;
+use App\Models\UgcTrack;
+use Illuminate\Console\Command;
+
+class UpdateUgcPropertiesWithDateCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'geohub:update-ugc-properties-with-dates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update the UGC properties with the createdAt and updatedAt dates';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command to update UGC properties with dates.
+     *
+     * This method retrieves all instances of UgcTrack, UgcPoi, and UgcMedia,
+     * and updates their properties with the createdAt and updatedAt dates if not already set.
+     *
+     * @return int Returns 0 on successful execution.
+     */
+    public function handle()
+    {
+        $this->updateProperties(UgcTrack::all());
+        $this->updateProperties(UgcPoi::all());
+        $this->updateProperties(UgcMedia::all());
+
+        return 0;
+    }
+
+    /**
+     * Update properties with createdAt and updatedAt dates.
+     *
+     * @param \Illuminate\Database\Eloquent\Collection $items
+     * @return void
+     */
+    private function updateProperties($items)
+    {
+        foreach ($items as $item) {
+            $properties = $item->properties;
+
+            if (!isset($properties['createdAt'])) {
+                $properties['createdAt'] = $item->created_at;
+                $properties['updatedAt'] = $item->created_at;
+                $item->properties = $properties;
+                $item->save();
+            }
+        }
+    }
+}

--- a/app/Console/Commands/UpdateUgcPropertiesWithDateCommand.php
+++ b/app/Console/Commands/UpdateUgcPropertiesWithDateCommand.php
@@ -65,7 +65,8 @@ class UpdateUgcPropertiesWithDateCommand extends Command
                 $properties['createdAt'] = $item->created_at;
                 $properties['updatedAt'] = $item->created_at;
                 $item->properties = $properties;
-                $item->save();
+                $item->timestamps = false;
+                $item->saveQuietly();
             }
         }
     }


### PR DESCRIPTION
This commit adds a new command, UpdateUgcPropertiesWithDateCommand, which updates the UGC properties with the createdAt and updatedAt dates. The command retrieves all instances of UgcTrack, UgcPoi, and UgcMedia and updates their properties if not already set.
