### PR TITLE
chore: Configure Telescope to monitor only API paths

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -49,7 +49,6 @@ class Kernel extends ConsoleKernel
         $schedule->command('geohub:update_pois_from_osm caipontedera@webmapp.it')->dailyAt('18:15');
         $schedule->command('geohub:update_track_from_osm caipontedera@webmapp.it')->dailyAt('19:15');
 
-
         // Index BLUBELL
         $schedule->command('geohub:index-tracks 48')->dailyAt('05:00');
         // Index PARCO MAREMMA
@@ -91,7 +90,7 @@ class Kernel extends ConsoleKernel
      */
     protected function commands()
     {
-        $this->load(__DIR__ . '/Commands');
+        $this->load(__DIR__.'/Commands');
 
         require base_path('routes/console.php');
     }

--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -20,17 +20,7 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
 
         $this->hideSensitiveRequestDetails();
 
-        Telescope::filter(function (IncomingEntry $entry) {
-            if ($this->app->environment('local')) {
-                return true;
-            }
-
-            return $entry->isReportableException() ||
-                $entry->isFailedRequest() ||
-                $entry->isFailedJob() ||
-                $entry->isScheduledTask() ||
-                $entry->hasMonitoredTag();
-        });
+        return true;
     }
 
     /**

--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -3,7 +3,6 @@
 namespace App\Providers;
 
 use Illuminate\Support\Facades\Gate;
-use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
 use Laravel\Telescope\TelescopeApplicationServiceProvider;
 

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -92,7 +92,7 @@ return [
     */
 
     'only_paths' => [
-        // 'api/*'
+        'api/*'
     ],
 
     'ignore_paths' => [

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -92,7 +92,7 @@ return [
     */
 
     'only_paths' => [
-        'api/*'
+        'api/*',
     ],
 
     'ignore_paths' => [


### PR DESCRIPTION
- Updated TelescopeServiceProvider to always allow logging
- Configured Telescope to only monitor 'api/*' paths