### PR TITLE
chore: normalize elevation attribute in POI update oc: 5098

### DIFF
--- a/app/Console/Commands/UpdatePOIFromOsm.php
+++ b/app/Console/Commands/UpdatePOIFromOsm.php
@@ -235,6 +235,11 @@ class UpdatePOIFromOsm extends Command
     private function updatePoiAttribute(EcPoi $poi, array $osmPoi, string $poiAttributeKey, string $osmPropertyKey)
     {
         if (array_key_exists($osmPropertyKey, $osmPoi['properties']) && $osmPoi['properties'][$osmPropertyKey] != null) {
+            // normalize attribute ele
+            $value = $osmPoi['properties'][$osmPropertyKey];
+            if ($osmPropertyKey == 'ele') {
+                $value = preg_replace('/[^0-9.]/', '', $value);
+            }
             // update the 'code' attribute of the poi
             if ($osmPropertyKey == 'ref') {
                 // update the 'code' attribute of the poi


### PR DESCRIPTION
Added normalization for the 'ele' property during POI updates to ensure only numeric values are retained. This prevents potential issues with non-numeric characters affecting data integrity.
