### PR TITLE
chore: add GeoJSON bounding box feature and UI enhancements oc: 4854

### DIFF
--- a/app/Models/App.php
+++ b/app/Models/App.php
@@ -629,4 +629,38 @@ class App extends Model
 
         return null;
     }
+
+    /**
+     * Get the bounding box geometry as a GeoJSON Feature.
+     *
+     * This function converts the bounding box stored in the `map_bbox` attribute
+     * (in the format [minX, minY, maxX, maxY]) into a GeoJSON Feature representing
+     * a rectangular Polygon.
+     *
+     * @return array|null A GeoJSON Feature array or null if invalid bbox
+     */
+    public function getBBoxFeature()
+    {
+        $bbox = json_decode($this->map_bbox);
+        //Verify that it is indeed an array with 4 elements (i.e.: minX, minY, maxX, maxY
+        if (is_array($bbox) && count($bbox) === 4) {
+            return [
+                'type' => 'Feature',
+                'geometry' => [
+                    'type' => 'Polygon',
+                    'coordinates' => [[
+                        [$bbox[0], $bbox[1]],
+                        [$bbox[2], $bbox[1]],
+                        [$bbox[2], $bbox[3]],
+                        [$bbox[0], $bbox[3]],
+                        [$bbox[0], $bbox[1]],
+                    ]],
+                ],
+                'properties' => [],
+            ];
+        }
+
+        return null;
+    }
+
 }

--- a/app/Nova/App.php
+++ b/app/Nova/App.php
@@ -749,6 +749,19 @@ class App extends Resource
                     },
                 ])
                 ->help(__('Bounding the map view <a href="https://boundingbox.klokantech.com/" target="_blank">create a bounding box</a>')),
+            Text::make(__('Bounding BOX'), 'map_bbox')
+                ->onlyOnDetail()
+                ->asHtml()
+                ->displayUsing(function ($value) {
+                    return '<code>' . e($value) . '</code>' .
+                        '<button onclick="navigator.clipboard.writeText(`' . e($value) . '`)" 
+                            style="margin-left:10px;padding:4px 10px;border:none;background:#e2e8f0;border-radius:4px;cursor:pointer;">
+                            ' . __('Copy') . '
+                        </button>';
+                }),
+            WmEmbedmapsField::make(__('Bounding Box Map'), function () {
+                    return ['feature' => $this->getBBoxFeature()];
+                }),                
             Number::make(__('Max Zoom'), 'map_max_zoom')
                 ->help(__('Maximum zoom level for the map'))
                 ->onlyOnDetail(),


### PR DESCRIPTION
Implement a new method to convert the bounding box into a GeoJSON Feature. This includes validation for the bounding box format. Additionally, enhance the UI by adding a display for the bounding box with a copy button and integrate a map visualization using the new feature.

- Added `getBBoxFeature` method to return GeoJSON representation.
- Updated Nova resource to include bounding box details with copy functionality.
- Integrated map visualization for better user experience.