### PR TITLE
fix: OC:5354 correct OSM feature ID handling in OutSourceImporterFeatureOSM2CAI

### DIFF
--- a/app/Classes/OutSourceImporter/OutSourceImporterFeatureOSM2CAI.php
+++ b/app/Classes/OutSourceImporter/OutSourceImporterFeatureOSM2CAI.php
@@ -65,7 +65,7 @@ class OutSourceImporterFeatureOSM2CAI extends OutSourceImporterFeatureAbstract
         foreach ($osmData as $key => $value) {
             $track->$key = $value;
         }
-        //override osmfeatures_id with the correct one
+        // override osmfeatures_id with the correct one
         $track->osmfeatures_id = $osmfeaturesId;
 
         // prepare feature parameters to pass to updateOrCreate function


### PR DESCRIPTION
Updated the query to fetch the correct OSM feature ID and ensured that the correct ID is used when creating or updating features. This change improves data integrity by aligning the source ID with the corresponding OSM feature ID.