### PR TITLE
OC: 5412 Fix_osm2cai_duplicated_outsource_features

### DIFF
--- a/app/Console/Commands/CleanupOsm2caiFeatures.php
+++ b/app/Console/Commands/CleanupOsm2caiFeatures.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\EcTrack;
+use App\Models\OutSourceFeature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class CleanupOsm2caiFeatures extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'geohub:clean-osm2cai-features
+                            {--dry-run : Only list features to be deleted, do not execute deletion}
+                            {--force : Force the deletion of orphaned features without confirmation}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Deletes OutSourceFeatures (and related EcTracks) linked to OSM2CAI provider whose source_id does not match a valid id or osmfeatures_id in the osm2cai database hiking_routes table. Requires --force to execute deletion.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $isDryRun = $this->option('dry-run');
+        $isForce = $this->option('force');
+        $providerName = 'App\Classes\OutSourceImporter\OutSourceImporterFeatureOSM2CAI';
+
+        $this->info('Starting OSM2CAI feature cleanup...');
+        if ($isDryRun) {
+            $this->warn('Dry Run mode enabled. No data will be deleted.');
+        }
+
+        // --- Step 1: Get all valid IDs (id and osmfeatures_id) from osm2cai DB ---
+        $this->info('Fetching valid IDs (id and osmfeatures_id) from osm2cai database...');
+        $validHikingRouteIdsLookup = [];
+        $validOsmFeaturesIdsLookup = [];
+        try {
+            $hikingRoutesData = DB::connection('out_source_osm')
+                ->table('hiking_routes')
+                ->select('id', 'osmfeatures_id')
+                ->get();
+
+            if ($hikingRoutesData->isEmpty()) {
+                $this->error('Could not fetch valid IDs from osm2cai database or the table is empty. Aborting.');
+                return 1;
+            }
+
+            // Create lookup arrays 
+            $validHikingRouteIdsLookup = array_flip($hikingRoutesData->pluck('id')->filter()->all());
+            $validOsmFeaturesIdsLookup = array_flip($hikingRoutesData->pluck('osmfeatures_id')->filter()->all());
+
+            $this->info('Found ' . count($validHikingRouteIdsLookup) . ' unique valid hiking route IDs and ' . count($validOsmFeaturesIdsLookup) . ' unique valid osmfeatures_ids.');
+        } catch (\Exception $e) {
+            Log::error("Error connecting to or querying osm2cai database: {$e->getMessage()}");
+            $this->error("Error connecting to or querying osm2cai database: {$e->getMessage()}");
+            return 1;
+        }
+
+        // --- Step 2: Find potentially orphaned OutSourceFeatures in Geohub ---
+        $this->info("Fetching OutSourceFeatures with provider '{$providerName}'coming from api endpoint");
+        $orphanedOsfIds = [];
+        $skippedOsfCountInvalidJson = 0;
+        $skippedOsfCountMissingSourceId = 0; // Counter for missing source_id
+        $checkedCount = 0;
+        $totalToCheck = OutSourceFeature::where('provider', $providerName)
+            ->where('endpoint', 'LIKE', '%https://osm2cai.cai.it/api/v1/hiking-routes/region%') // Filter by api endpoint
+            ->count();
+
+        if ($totalToCheck === 0) {
+            $this->info("No OutSourceFeatures found for provider '{$providerName}'. Nothing to do.");
+            return 0;
+        }
+
+        $progressBar = $this->output->createProgressBar($totalToCheck);
+        $progressBar->start();
+
+        // Use chunking to avoid memory issues with large datasets
+        OutSourceFeature::where('provider', $providerName)
+            ->where('endpoint', 'LIKE', '%https://osm2cai.cai.it/api/v1/hiking-routes/region%') // Filter by api endpoint
+            ->select('id', 'source_id', 'raw_data') // Select id, source_id, and raw_data
+            ->chunkById(500, function ($outSourceFeatures) use (&$orphanedOsfIds, &$skippedOsfCountInvalidJson, &$skippedOsfCountMissingSourceId, $validHikingRouteIdsLookup, $validOsmFeaturesIdsLookup, &$checkedCount, $progressBar) {
+                foreach ($outSourceFeatures as $osf) {
+                    $checkedCount++;
+                    $progressBar->advance();
+
+                    // Check if source_id exists
+                    $sourceId = $osf->source_id;
+                    if (empty($sourceId)) {
+                        Log::warning("Skipping OutSourceFeature ID {$osf->id}: Missing or empty source_id.");
+                        $skippedOsfCountMissingSourceId++;
+                        continue;
+                    }
+
+                    $isOrphan = false;
+                    // Perform matching based on source_id format
+                    if (strpos((string)$sourceId, 'R') === 0) {
+                        // Source ID starts with 'R', check against osmfeatures_id
+                        if (!isset($validOsmFeaturesIdsLookup[$sourceId])) {
+                            $isOrphan = true;
+                        }
+                    } else {
+                        // Source ID does not start with 'R', check against id
+                        // Attempt conversion to integer if it looks like one, as hiking_route.id is likely integer
+                        $idToCheck = $sourceId;
+                        if (is_numeric($idToCheck)) {
+                            $idToCheck = (int)$idToCheck;
+                        }
+                        if (!isset($validHikingRouteIdsLookup[$idToCheck])) {
+                            $isOrphan = true;
+                        }
+                    }
+
+                    // 4. If checks failed, mark as orphan
+                    if ($isOrphan) {
+                        $orphanedOsfIds[] = $osf->id; // Store the OutSourceFeature's own ID
+                    }
+                }
+            });
+
+        $progressBar->finish();
+        $this->newLine(); // Add a newline after the progress bar
+
+        $this->info("Checked {$checkedCount} OutSourceFeatures.");
+        if ($skippedOsfCountInvalidJson > 0) {
+            $this->warn("Skipped {$skippedOsfCountInvalidJson} OutSourceFeatures due to invalid JSON in raw_data (check log for details).");
+        }
+        if ($skippedOsfCountMissingSourceId > 0) {
+            $this->warn("Skipped {$skippedOsfCountMissingSourceId} OutSourceFeatures due to missing or empty source_id (check log for details).");
+        }
+
+        if (empty($orphanedOsfIds)) {
+            $this->info('No orphaned OutSourceFeatures found based on source_id matching.');
+            return 0;
+        }
+
+        $this->warn('Found ' . count($orphanedOsfIds) . ' potentially orphaned OutSourceFeatures (based on source_id matching). ');
+
+        // --- Step 3: Find related EcTracks ---
+        $this->info('Finding related EcTracks for orphaned OutSourceFeatures...');
+        $orphanedEcTrackIds = EcTrack::whereIn('out_source_feature_id', $orphanedOsfIds)
+            ->pluck('id')
+            ->toArray();
+
+        if (!empty($orphanedEcTrackIds)) {
+            $this->warn('Found ' . count($orphanedEcTrackIds) . ' related EcTracks to be deleted.');
+        } else {
+            $this->info('No related EcTracks found for the orphaned OutSourceFeatures.');
+        }
+
+        // --- Step 4: Perform Deletion or Dry Run ---
+        $isForce = $this->option('force');
+
+        // Define count variables
+        $orphanedOsfIdsCount = count($orphanedOsfIds);
+        $orphanedEcTrackIdsCount = count($orphanedEcTrackIds);
+
+        if ($isDryRun || !$isForce) {
+            // Perform dry run if --dry-run is set OR if --force is NOT set
+            $this->info("Dry run: Found {$orphanedOsfIdsCount} orphaned OutSourceFeatures that would be deleted.");
+            if ($orphanedEcTrackIdsCount > 0) {
+                $this->info("Dry run: Found {$orphanedEcTrackIdsCount} related EcTracks that would be deleted.");
+            }
+            if (!$isDryRun && !$isForce) { // Add specific message if neither option was used
+                $this->warn('Execution halted. Use the --force option to perform the actual deletion.');
+            } else {
+                $this->info('Dry run finished. No data was deleted.');
+            }
+        } elseif ($isForce) { // Only delete if --force is explicitly set
+            $this->warn("Executing deletion as --force option was specified...");
+
+            // Delete EcTracks first (if any)
+            if (!empty($orphanedEcTrackIds)) {
+                $this->info('Deleting related EcTracks...');
+                $deletedEcTracksCount = EcTrack::destroy($orphanedEcTrackIds);
+                $this->info("Deleted {$deletedEcTracksCount} EcTracks.");
+            } else {
+                $this->info('No EcTracks to delete.');
+            }
+
+            // Delete OutSourceFeatures
+            $this->info('Deleting orphaned OutSourceFeatures...');
+            $deletedOsfCount = OutSourceFeature::destroy($orphanedOsfIds);
+            $this->info("Deleted {$deletedOsfCount} OutSourceFeatures.");
+
+            $this->info('Cleanup finished successfully.');
+        }
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/UpdatePOIFromOsm.php
+++ b/app/Console/Commands/UpdatePOIFromOsm.php
@@ -86,7 +86,7 @@ class UpdatePOIFromOsm extends Command
         // Retrieve all pois belonging to the user
         $pois = EcPoi::where('user_id', $user->id)->get();
 
-        $this->info('Updating pois for user ' . $user->name . ' (' . $user->email . ')...');
+        $this->info('Updating pois for user '.$user->name.' ('.$user->email.')...');
 
         foreach ($pois as $poi) {
             // Update the data for each poi and save the pois that were not updated
@@ -97,7 +97,7 @@ class UpdatePOIFromOsm extends Command
         // print to terminal all the pois not updated
         if (! empty($this->errorPois)) {
             foreach ($this->errorPois as $poi) {
-                $this->error('Poi ' . $poi->name . ' (osmid: ' . $poi->osmid . ' ) not updated.');
+                $this->error('Poi '.$poi->name.' (osmid: '.$poi->osmid.' ) not updated.');
             }
         }
         $this->generatePoisJson($user);
@@ -111,17 +111,17 @@ class UpdatePOIFromOsm extends Command
         $apps = App::where('user_id', $user->id)->get();
 
         if ($apps->isEmpty()) {
-            $this->info('No apps found for user: ' . $user->email);
+            $this->info('No apps found for user: '.$user->email);
         } else {
             foreach ($apps as $app) {
-                $this->info('Generating App POIs for App ID: ' . $app->id . '...');
+                $this->info('Generating App POIs for App ID: '.$app->id.'...');
 
                 try {
                     $app->GenerateAppPois();
-                    $this->info('App POIs generated successfully for App ID: ' . $app->id);
+                    $this->info('App POIs generated successfully for App ID: '.$app->id);
                 } catch (Exception $e) {
-                    $this->error('Error generating App POIs for App ID: ' . $app->id . ': ' . $e->getMessage());
-                    Log::error('Error generating App POIs for App ID: ' . $app->id . ': ' . $e->getMessage());
+                    $this->error('Error generating App POIs for App ID: '.$app->id.': '.$e->getMessage());
+                    Log::error('Error generating App POIs for App ID: '.$app->id.': '.$e->getMessage());
                 }
             }
         }
@@ -130,20 +130,20 @@ class UpdatePOIFromOsm extends Command
     // Update the data for a single poi
     private function updatePoiData(EcPoi $poi)
     {
-        $this->info('Updating poi ' . $poi->name . ' (' . $poi->osmid . ')...');
+        $this->info('Updating poi '.$poi->name.' ('.$poi->osmid.')...');
 
         try {
             // Retrieve the geojson data from OSM based on the poi's osmid
-            $osmPoi = json_decode(OsmClient::getGeojson('node/' . $poi->osmid), true);
+            $osmPoi = json_decode(OsmClient::getGeojson('node/'.$poi->osmid), true);
             // if $osmPoi['_api_url'] is empty log error and skip the poi
             if (empty($osmPoi['_api_url'])) {
-                $this->error('Error while retrieving data from OSM for poi ' . $poi->name . ' (https://api.openstreetmap.org/api/0.6/node/' . $poi->osmid . '.json). Url not valid');
+                $this->error('Error while retrieving data from OSM for poi '.$poi->name.' (https://api.openstreetmap.org/api/0.6/node/'.$poi->osmid.'.json). Url not valid');
                 array_push($this->errorPois, $poi);
 
                 return;
             }
         } catch (Exception $e) {
-            $this->error('Error while retrieving data from OSM for poi ' . $poi->name . ' (' . $poi->osmid . '). Error: ' . $e->getMessage());
+            $this->error('Error while retrieving data from OSM for poi '.$poi->name.' ('.$poi->osmid.'). Error: '.$e->getMessage());
             array_push($this->errorPois, $poi);
 
             return;
@@ -151,7 +151,7 @@ class UpdatePOIFromOsm extends Command
 
         if (array_key_exists('properties', $osmPoi) && array_key_exists('wikimedia_commons', $osmPoi['properties'])) {
             $wikimediaCommonsTitle = $osmPoi['properties']['wikimedia_commons'];
-            $metadataUrl = 'https://commons.wikimedia.org/w/api.php?action=query&prop=imageinfo&iiprop=timestamp|url|sha1&format=json&titles=' . $wikimediaCommonsTitle;
+            $metadataUrl = 'https://commons.wikimedia.org/w/api.php?action=query&prop=imageinfo&iiprop=timestamp|url|sha1&format=json&titles='.$wikimediaCommonsTitle;
 
             try {
                 // First GET request to fetch metadata
@@ -164,18 +164,18 @@ class UpdatePOIFromOsm extends Command
                     $currentFeatureImage = $poi->featureImage;
 
                     // Check if the feature image needs to be updated
-                    if ($currentFeatureImage && new \DateTime($currentFeatureImage->updated_at) >= $imageUpdatedAt && !empty($currentFeatureImage->url)) {
-                        $this->info('[is up to date] Feature image for poi ' . $poi->name . ' .');
+                    if ($currentFeatureImage && new \DateTime($currentFeatureImage->updated_at) >= $imageUpdatedAt && ! empty($currentFeatureImage->url)) {
+                        $this->info('[is up to date] Feature image for poi '.$poi->name.' .');
 
                         continue;
                     }
-                    $this->info('[updating] Feature image for poi ' . $poi->name);
+                    $this->info('[updating] Feature image for poi '.$poi->name);
                     // Second GET request to fetch the actual image only if necessary
                     $options = ['http' => ['user_agent' => 'custom user agent string']];
                     $context = stream_context_create($options);
                     $ec_storage_name = config('geohub.ec_media_storage_name');
                     $image_content = file_get_contents($imageUrl, false, $context);
-                    $media_path = 'ec_media/' . $page['title'];
+                    $media_path = 'ec_media/'.$page['title'];
                     Storage::disk($ec_storage_name)->put($media_path, $image_content);
                     Log::info('Updating EC Media.');
 
@@ -203,13 +203,13 @@ class UpdatePOIFromOsm extends Command
 
                     if ($poi->ecMedia()->count() < 1) {
                         if ($poi->feature_image) {
-                            Log::info('Updating: ' . $poi->id);
+                            Log::info('Updating: '.$poi->id);
                             $poi->ecMedia()->sync($poi->featureImage);
                         }
                     }
                 }
             } catch (Exception $e) {
-                Log::info('Error updating EcMedia with POI id: ' . $poi->id . "\n ERROR: " . $e->getMessage());
+                Log::info('Error updating EcMedia with POI id: '.$poi->id."\n ERROR: ".$e->getMessage());
             }
         }
 
@@ -224,11 +224,11 @@ class UpdatePOIFromOsm extends Command
         // Set the 'skip_geomixer_tech' field to true if the 'ele' attribute was updated
         if ($poi->isDirty('ele')) {
             $poi->skip_geomixer_tech = true;
-            $this->info('Poi ' . $poi->name . ' (osmid: ' . $poi->osmid . ') ele updated. Skip_geomixer_tech set to true.');
+            $this->info('Poi '.$poi->name.' (osmid: '.$poi->osmid.') ele updated. Skip_geomixer_tech set to true.');
         }
         // Save the updated poi
         $poi->save();
-        $this->info('Poi ' . $poi->name . ' (osmid: ' . $poi->osmid . ') updated.');
+        $this->info('Poi '.$poi->name.' (osmid: '.$poi->osmid.') updated.');
     }
 
     // Update attribute of the poi if it exists in the OSM data
@@ -249,13 +249,13 @@ class UpdatePOIFromOsm extends Command
                 $poi->$poiAttributeKey = $value;
             }
         } catch (Exception $e) {
-            Log::info('Error: ' . $poi->id . "\n ERROR: " . $e->getMessage());
+            Log::info('Error: '.$poi->id."\n ERROR: ".$e->getMessage());
         }
     }
 
     private function updatePoiGeometry(EcPoi $poi, array $osmPoi)
     {
-        $poi->geometry = DB::raw("ST_GeomFromGeojson('" . json_encode($osmPoi['geometry']) . ")')");
+        $poi->geometry = DB::raw("ST_GeomFromGeojson('".json_encode($osmPoi['geometry']).")')");
         $poi->save();
     }
 

--- a/app/Nova/EcPoi.php
+++ b/app/Nova/EcPoi.php
@@ -146,7 +146,7 @@ class EcPoi extends Resource
                 //     return '<a href="'.route('api.ec.poi.json', ['id' => $this->id]).'" target="_blank">[x]</a>';
                 // })->asHtml(),
                 Text::make('API', function () {
-                    return '<a href="/api/ec/poi/' . $this->id . '" target="_blank">[x]</a>';
+                    return '<a href="/api/ec/poi/'.$this->id.'" target="_blank">[x]</a>';
                 })->asHtml(),
             ];
         } else {
@@ -264,7 +264,7 @@ class EcPoi extends Resource
                             $out = 'No related Url';
                         }
 
-                        return $out . $help;
+                        return $out.$help;
                     })->asHtml(),
                     ExternalImage::make(__('Feature Image'), function () {
                         $url = isset($this->model()->featureImage) ? $this->model()->featureImage->url : '';

--- a/app/Nova/Filters/AppFilter.php
+++ b/app/Nova/Filters/AppFilter.php
@@ -4,8 +4,8 @@ namespace App\Nova\Filters;
 
 use App\Models\App;
 use Illuminate\Http\Request;
-use Laravel\Nova\Filters\Filter;
 use Illuminate\Support\Facades\DB;
+use Laravel\Nova\Filters\Filter;
 
 class AppFilter extends Filter
 {
@@ -15,11 +15,13 @@ class AppFilter extends Filter
      * @var string
      */
     public $component = 'select-filter';
+
     protected $relationName = 'ugc_pois';
 
     public function setRelation($relationName)
     {
         $this->relationName = $relationName;
+
         return $this;
     }
 
@@ -48,14 +50,14 @@ class AppFilter extends Filter
             $apps = App::whereExists(function ($query) {
                 $query->select(DB::raw(1))
                     ->from($this->relationName)
-                    ->whereRaw('CAST(apps.id AS VARCHAR) = ' . $this->relationName . '.app_id');
+                    ->whereRaw('CAST(apps.id AS VARCHAR) = '.$this->relationName.'.app_id');
             })->orderBy('name')->get()->toArray();
         } else {
             $apps = App::where('user_id', $request->user()->id)
                 ->whereExists(function ($query) {
                     $query->select(DB::raw(1))
                         ->from($this->relationName)
-                        ->whereRaw('CAST(apps.id AS VARCHAR) = ' . $this->relationName . '.app_id');
+                        ->whereRaw('CAST(apps.id AS VARCHAR) = '.$this->relationName.'.app_id');
                 })->orderBy('name')->get()->toArray();
         }
         foreach ($apps as $app) {

--- a/app/Nova/Filters/UgcUserRelationFilter.php
+++ b/app/Nova/Filters/UgcUserRelationFilter.php
@@ -5,37 +5,43 @@ namespace App\Nova\Filters;
 use App\Models\App;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Laravel\Nova\Filters\Filter;
 use Illuminate\Support\Facades\DB;
+use Laravel\Nova\Filters\Filter;
 
 class UgcUserRelationFilter extends Filter
 {
     public $component = 'select-filter';
+
     protected $fieldAttribute;
+
     protected $filterBy;
+
     protected $relationName = 'ugc_pois';
 
     /**
      * Imposta il nome della relazione da utilizzare
      *
-     * @param string $relationName Nome della relazione (ugc_pois, ugc_tracks, ugc_medias)
+     * @param  string  $relationName  Nome della relazione (ugc_pois, ugc_tracks, ugc_medias)
      * @return $this
      */
     public function setRelation($relationName)
     {
         $this->relationName = $relationName;
+
         return $this;
     }
 
     public function fieldAttribute($fieldAttribute)
     {
         $this->fieldAttribute = $fieldAttribute;
+
         return $this;
     }
 
     public function filterBy($filterBy)
     {
         $this->filterBy = $filterBy;
+
         return $this;
     }
 
@@ -53,20 +59,20 @@ class UgcUserRelationFilter extends Filter
             $users = User::whereExists(function ($query) {
                 $query->select(DB::raw(1))
                     ->from($this->relationName)
-                    ->whereRaw('users.id = ' . $this->relationName . '.user_id');
+                    ->whereRaw('users.id = '.$this->relationName.'.user_id');
             })->orderBy('name')->get()->toArray();
         } else {
             $apps = App::where('user_id', $request->user()->id)
                 ->whereExists(function ($query) {
                     $query->select(DB::raw(1))
                         ->from($this->relationName)
-                        ->whereRaw('CAST(apps.id AS VARCHAR) = ' . $this->relationName . '.app_id');
+                        ->whereRaw('CAST(apps.id AS VARCHAR) = '.$this->relationName.'.app_id');
                 })->orderBy('name')->get()->pluck('id')->toArray();
-            $users = User::where('app_id',  $apps)
+            $users = User::where('app_id', $apps)
                 ->whereExists(function ($query) {
                     $query->select(DB::raw(1))
                         ->from($this->relationName)
-                        ->whereRaw('users.id = ' . $this->relationName . '.user_id');
+                        ->whereRaw('users.id = '.$this->relationName.'.user_id');
                 })->orderBy('name')->get()->toArray();
         }
 

--- a/app/Nova/UgcPoi.php
+++ b/app/Nova/UgcPoi.php
@@ -10,8 +10,7 @@ use App\Nova\Filters\AppFilter;
 use App\Nova\Filters\SchemaFilter;
 use App\Nova\Filters\ShareUgcPoiFilter;
 use App\Nova\Filters\UgcCreationDateFilter;
-use App\Nova\Filters\UgcUserFilter;
-use App\Nova\Filters\UserFilter;
+use App\Nova\Filters\UgcUserRelationFilter;
 use Exception;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
@@ -22,10 +21,8 @@ use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Heading;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
-use Suenerds\NovaSearchableBelongsToFilter\NovaSearchableBelongsToFilter;
 use Titasgailius\SearchRelations\SearchesRelations;
 use Webmapp\WmEmbedmapsField\WmEmbedmapsField;
-use App\Nova\Filters\UgcUserRelationFilter;
 
 class UgcPoi extends Resource
 {
@@ -160,7 +157,7 @@ class UgcPoi extends Resource
                         if ($currentSchema) {
                             // Aggiungi una riga all'inizio per il tipo di form
                             $typeLabel = reset($currentSchema['label']); // Assumi che 'label' esista e abbia almeno una voce
-                            $html = '<strong>' . htmlspecialchars($typeLabel) . '</strong>';
+                            $html = '<strong>'.htmlspecialchars($typeLabel).'</strong>';
 
                             return $html;
                         }
@@ -193,7 +190,7 @@ class UgcPoi extends Resource
                         if ($currentSchema) {
                             // Aggiungi una riga all'inizio per il tipo di form
                             $typeLabel = reset($currentSchema['label']); // Assumi che 'label' esista e abbia almeno una voce
-                            $html .= '<td><strong>tipo di form</strong></td><td>' . htmlspecialchars($typeLabel) . '</td>';
+                            $html .= '<td><strong>tipo di form</strong></td><td>'.htmlspecialchars($typeLabel).'</td>';
 
                             foreach ($currentSchema['fields'] as $field) {
                                 $fieldLabel = reset($field['label']);
@@ -214,14 +211,14 @@ class UgcPoi extends Resource
 
                                 if (isset($fieldValue)) {
                                     $html .= '<tr>';
-                                    $html .= '<td><strong>' . htmlspecialchars($fieldLabel) . '</strong></td>';
-                                    $html .= '<td>' . htmlspecialchars($fieldValue) . '</td>';
+                                    $html .= '<td><strong>'.htmlspecialchars($fieldLabel).'</strong></td>';
+                                    $html .= '<td>'.htmlspecialchars($fieldValue).'</td>';
                                     $html .= '</tr>';
                                 }
                             }
                             $html .= '</table>';
 
-                            return $html . $help;
+                            return $html.$help;
                         }
                     }
                 }

--- a/app/Nova/UgcTrack.php
+++ b/app/Nova/UgcTrack.php
@@ -19,7 +19,6 @@ use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Heading;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
-use Suenerds\NovaSearchableBelongsToFilter\NovaSearchableBelongsToFilter;
 use Titasgailius\SearchRelations\SearchesRelations;
 use Webmapp\WmEmbedmapsField\WmEmbedmapsField;
 
@@ -140,7 +139,7 @@ class UgcTrack extends Resource
                         if ($currentSchema) {
                             // Aggiungi una riga all'inizio per il tipo di form
                             $typeLabel = reset($currentSchema['label']); // Assumi che 'label' esista e abbia almeno una voce
-                            $html = '<strong>' . htmlspecialchars($typeLabel) . '</strong>';
+                            $html = '<strong>'.htmlspecialchars($typeLabel).'</strong>';
 
                             return $html;
                         }
@@ -205,7 +204,7 @@ class UgcTrack extends Resource
                         if ($currentSchema) {
                             // Aggiungi una riga all'inizio per il tipo di form
                             $typeLabel = reset($currentSchema['label']); // Assumi che 'label' esista e abbia almeno una voce
-                            $html .= '<td><strong>tipo di form</strong></td><td>' . htmlspecialchars($typeLabel) . '</td>';
+                            $html .= '<td><strong>tipo di form</strong></td><td>'.htmlspecialchars($typeLabel).'</td>';
 
                             foreach ($currentSchema['fields'] as $field) {
                                 $fieldLabel = reset($field['label']);
@@ -226,14 +225,14 @@ class UgcTrack extends Resource
 
                                 if (isset($fieldValue)) {
                                     $html .= '<tr>';
-                                    $html .= '<td><strong>' . htmlspecialchars($fieldLabel) . '</strong></td>';
-                                    $html .= '<td>' . htmlspecialchars($fieldValue) . '</td>';
+                                    $html .= '<td><strong>'.htmlspecialchars($fieldLabel).'</strong></td>';
+                                    $html .= '<td>'.htmlspecialchars($fieldValue).'</td>';
                                     $html .= '</tr>';
                                 }
                             }
                             $html .= '</table>';
 
-                            return $html . $help;
+                            return $html.$help;
                         }
                     }
                 }
@@ -272,7 +271,7 @@ class UgcTrack extends Resource
                 $result = [];
 
                 foreach ($rawData as $key => $value) {
-                    $result[] = $key . ' = ' . json_encode($value);
+                    $result[] = $key.' = '.json_encode($value);
                 }
 
                 return implode('<br>', $result);

--- a/scripts/import_sync_osm2cai_all.sh
+++ b/scripts/import_sync_osm2cai_all.sh
@@ -141,3 +141,6 @@ echo "generate queue jobs for all needed calculations -  Sardegna ..."
 php artisan geohub:generate_hoqu_script --osf_endpoint="https://osm2cai.cai.it/api/v1/hiking-routes/region/z/1,2,3,4" osm2cai_z
 
 echo "finished OSM2CAI all regioni"
+
+echo "Cleaning up orphaned OSM2CAI features from Geohub..."
+php artisan geohub:clean-osm2cai-features --force


### PR DESCRIPTION
- Introduced a new console command `CleanupOsm2caiFeatures` to delete orphaned OutSourceFeatures and related EcTracks linked to the OSM2CAI provider.
- The command supports a dry-run option to preview deletions and a force option to execute them without confirmation.
- Updated the import script to include cleanup execution after syncing OSM2CAI features.