### PR TITLE
feat(app): ✨ add toggle for 'Draw POI' feature oc:5707

### DIFF
--- a/app/Nova/App.php
+++ b/app/Nova/App.php
@@ -305,6 +305,16 @@ class App extends Resource
                 ->canSee(function ($request) {
                     return $request->user()->hasRole('Admin');
                 }),
+            //TODO: aggiungere al wmpackage
+            Toggle::make(__('Show Draw POI'), 'draw_poi_show')
+                ->trueValue('On')
+                ->falseValue('Off')
+                ->default(false)
+                ->hideFromIndex()
+                ->help(__('Enables the draw POI feature in the web app.'))
+                ->canSee(function ($request) {
+                    return $request->user()->hasRole('Admin');
+                }),
             Toggle::make(__('Show splash screen'), 'splash_screen_show')
                 ->trueValue('On')
                 ->falseValue('Off')

--- a/app/Traits/ConfTrait.php
+++ b/app/Traits/ConfTrait.php
@@ -88,6 +88,7 @@ trait ConfTrait
         $data = [];
 
         $data['WEBAPP']['draw_track_show'] = $this->draw_track_show;
+        $data['WEBAPP']['draw_poi_show'] = $this->draw_poi_show; //TODO: aggiungere al wmpackage
         $data['WEBAPP']['editing_inline_show'] = $this->editing_inline_show;
         $data['WEBAPP']['splash_screen_show'] = $this->splash_screen_show;
         if ($this->gu_id) {

--- a/database/migrations/2025_06_09_153618_add_draw_poi_show_to_apps.php
+++ b/database/migrations/2025_06_09_153618_add_draw_poi_show_to_apps.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+//TODO: aggiungere al wmpackage
+class AddDrawPoiShowToApps extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('apps', function (Blueprint $table) {
+            $table->boolean('draw_poi_show')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('apps', function (Blueprint $table) {
+            $table->dropColumn('draw_poi_show');
+        });
+    }
+}


### PR DESCRIPTION
Added a new toggle option 'Show Draw POI' in the application to enable or disable the draw POI feature in the web app. This option is only visible to users with the 'Admin' role.

- Updated `App.php` to include the new toggle.
- Modified `ConfTrait.php` to store the new configuration.
- Added a new migration to include `draw_poi_show` column in the `apps` table.

Note: TODO comments indicate the feature needs to be added to the wmpackage.
