### PR TITLE
fix(filters): 🐛 update SchemaFilter to include additional condition oc: 5684

### DIFF
--- a/app/Nova/Filters/SchemaFilter.php
+++ b/app/Nova/Filters/SchemaFilter.php
@@ -26,7 +26,10 @@ class SchemaFilter extends Filter
      */
     public function apply(Request $request, $query, $value)
     {
-        return $query->whereRaw("raw_data->>'id' = ?", [$value]);
+        return $query->where(function ($query) use ($value) {
+            $query->whereRaw("raw_data->>'id' = ?", [$value])
+                ->orWhereRaw("properties->'form'->>'id' = ?", [$value]);
+        });
     }
 
     public function __construct($type = 'ugc_pois')


### PR DESCRIPTION
Enhanced the `apply` method in `SchemaFilter` to include an OR condition. Now it checks both `raw_data->>'id'` and `properties->'form'->>'id'` against the provided value. This ensures broader matching criteria for filtering.
