### PR TITLE
feat(app): ✨ introduce AppZoom enum for zoom level constants oc:5865

### DIFF
--- a/app/Enums/AppZoom.php
+++ b/app/Enums/AppZoom.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+class AppZoom
+{
+    public const MIN_ZOOM = 1;
+    public const MAX_ZOOM = 25;
+}

--- a/app/Nova/App.php
+++ b/app/Nova/App.php
@@ -3,6 +3,7 @@
 namespace App\Nova;
 
 use App\Enums\AppTiles;
+use App\Enums\AppZoom;
 use App\Nova\Actions\elasticIndex;
 use App\Nova\Actions\GenerateAllAwsTracks;
 use App\Nova\Actions\GenerateAppConfigAction;
@@ -159,9 +160,9 @@ class App extends Resource
             Text::make('Name')->sortable(),
             Text::make('Customer Name'),
             Text::make(__('APP'), function () {
-                $urlAny = 'https://'.$this->model()->id.'.app.webmapp.it';
-                $urlDesktop = 'https://'.$this->model()->id.'.app.geohub.webmapp.it';
-                $urlMobile = 'https://'.$this->model()->id.'.mobile.webmapp.it';
+                $urlAny = 'https://' . $this->model()->id . '.app.webmapp.it';
+                $urlDesktop = 'https://' . $this->model()->id . '.app.geohub.webmapp.it';
+                $urlMobile = 'https://' . $this->model()->id . '.mobile.webmapp.it';
 
                 return "
                 <a class='btn btn-default btn-primary flex items-center justify-center px-3' style='margin:3px' href='$urlAny' target='_blank'>ANY</a>
@@ -374,9 +375,9 @@ class App extends Resource
                 HTML;
             })->asHtml(),
             Text::make(__('APP'), function () {
-                $urlAny = 'https://'.$this->model()->id.'.app.webmapp.it';
-                $urlDesktop = 'https://'.$this->model()->id.'.app.geohub.webmapp.it';
-                $urlMobile = 'https://'.$this->model()->id.'.mobile.webmapp.it';
+                $urlAny = 'https://' . $this->model()->id . '.app.webmapp.it';
+                $urlDesktop = 'https://' . $this->model()->id . '.app.geohub.webmapp.it';
+                $urlMobile = 'https://' . $this->model()->id . '.mobile.webmapp.it';
 
                 return <<<HTML
                 <a class='btn btn-default btn-primary' style='margin:3px' href='$urlAny' target='_blank'>ANY</a>
@@ -618,15 +619,15 @@ class App extends Resource
                 }),
             // TODO: ADD2WMPACKAGE
             NovaSliderField::make(__('Min Zoom Features In Viewport'), 'min_zoom_features_in_viewport')
-                ->min(5)
-                ->max(25)
+                ->min(AppZoom::MIN_ZOOM)
+                ->max(AppZoom::MAX_ZOOM)
                 ->default(10)
                 ->onlyOnForms()
                 ->help(__('Minimum zoom level for enable the Features In Viewport')),
             // TODO: ADD2WMPACKAGE
             NovaSliderField::make(__('Max Zoom Features In Viewport'), 'max_zoom_features_in_viewport')
-                ->min(5)
-                ->max(25)
+                ->min(AppZoom::MIN_ZOOM)
+                ->max(AppZoom::MAX_ZOOM)
                 ->default(12)
                 ->onlyOnForms()
                 ->help(__('Maximum zoom level for enable the Features In Viewport')),
@@ -688,7 +689,7 @@ class App extends Resource
                 ->language('json')
                 ->rules('json')
                 ->default('{"HOME": []}')
-                ->help(__('This code in JSON format organizes the elements on the app\'s home. Knowledge of JSON format required.').view('layers', ['layers' => $this->layers])->render()),
+                ->help(__('This code in JSON format organizes the elements on the app\'s home. Knowledge of JSON format required.') . view('layers', ['layers' => $this->layers])->render()),
         ];
     }
 
@@ -802,8 +803,8 @@ class App extends Resource
                 ->hideWhenCreating()
                 ->help(__('SVG icon shown in the filter')),
             NovaSliderField::make(__('Max Zoom'), 'map_max_zoom')
-                ->min(5)
-                ->max(25)
+                ->min(AppZoom::MIN_ZOOM)
+                ->max(AppZoom::MAX_ZOOM)
                 ->default(16)
                 ->onlyOnForms()
                 ->help(__('Maximum zoom level for the map')),
@@ -813,8 +814,8 @@ class App extends Resource
                 ->default(6)
                 ->help(__('Set max stroke width of line string, the max stroke width is applied when the app is on max level zoom')),
             NovaSliderField::make(__('Min Zoom'), 'map_min_zoom')
-                ->min(5)
-                ->max(19)
+                ->min(AppZoom::MIN_ZOOM)
+                ->max(AppZoom::MAX_ZOOM)
                 ->default(12)
                 ->help(__('Minimum zoom level for the map')),
             Number::make(__('Min Stroke width'), 'map_min_stroke_width')
@@ -823,7 +824,7 @@ class App extends Resource
                 ->default(3)
                 ->help(__('Set min stroke width of line string, the min stroke width is applied when the app is on min level zoom')),
             NovaSliderField::make(__('Def Zoom'), 'map_def_zoom')
-                ->min(5)
+                ->min(1)
                 ->max(19)
                 ->interval(0.1)
                 ->default(12)
@@ -836,7 +837,7 @@ class App extends Resource
                     function ($attribute, $value, $fail) {
                         $decoded = json_decode($value);
                         if (is_array($decoded) == false) {
-                            $fail('The '.$attribute.' is invalid. Follow the example [9.9456,43.9116,11.3524,45.0186]');
+                            $fail('The ' . $attribute . ' is invalid. Follow the example [9.9456,43.9116,11.3524,45.0186]');
                         }
                     },
                 ])
@@ -845,10 +846,10 @@ class App extends Resource
                 ->onlyOnDetail()
                 ->asHtml()
                 ->displayUsing(function ($value) {
-                    return '<code>'.e($value).'</code>'.
-                        '<button onclick="navigator.clipboard.writeText(`'.e($value).'`)" 
+                    return '<code>' . e($value) . '</code>' .
+                        '<button onclick="navigator.clipboard.writeText(`' . e($value) . '`)" 
                             style="margin-left:10px;padding:4px 10px;border:none;background:#e2e8f0;border-radius:4px;cursor:pointer;">
-                            '.__('Copy').'
+                            ' . __('Copy') . '
                         </button>';
                 }),
             WmEmbedmapsField::make(__('Bounding Box Map'), function () {
@@ -872,7 +873,7 @@ class App extends Resource
             Number::make(__('ref_on_track_min_zoom'))->min(10)->max(20)
                 ->help(__('Set minimum zoom at which ref parameter is shown on tracks line in general maps (ref_on_track_show must be true)')),
             Text::make(__('POIS API'), function () {
-                $url = '/api/v1/app/'.$this->model()->id.'/pois.geojson';
+                $url = '/api/v1/app/' . $this->model()->id . '/pois.geojson';
 
                 return <<<HTML
                     <a class='btn btn-default btn-primary' href='$url' target='_blank'>POIS API</a>
@@ -1113,15 +1114,15 @@ class App extends Resource
                 ->onlyOnForms()
                 ->help(__('Poi Icon Radius: Select the radius for the POI icons.')),
             NovaSliderField::make(__('Poi Min Zoom'), 'poi_min_zoom')
-                ->min(5)
-                ->max(19)
+                ->min(AppZoom::MIN_ZOOM)
+                ->max(AppZoom::MAX_ZOOM)
                 ->default(13)
                 ->interval(0.1)
                 ->onlyOnForms()
                 ->help(__('Poi Min Zoom: Set the minimum zoom level at which POIs are visible.')),
             NovaSliderField::make(__('Poi Label Min Zoom'), 'poi_label_min_zoom')
-                ->min(5)
-                ->max(19)
+                ->min(AppZoom::MIN_ZOOM)
+                ->max(AppZoom::MAX_ZOOM)
                 ->default(10.5)
                 ->interval(0.1)
                 ->onlyOnForms()
@@ -1164,7 +1165,7 @@ class App extends Resource
                 ->help(__('Main theme of the POIs used by the app.')),
 
             Text::make('Download GeoJSON collection', function () {
-                $url = url('/api/v1/app/'.$this->id.'/pois.geojson');
+                $url = url('/api/v1/app/' . $this->id . '/pois.geojson');
 
                 return <<<HTML
                             <a class="btn btn-default btn-primary" href="{$url}" target="_blank">Download</a>
@@ -1189,7 +1190,7 @@ class App extends Resource
             Image::make(__('Logo Homepage'), 'logo_homepage')
                 ->rules('image', 'mimes:svg')
                 ->disk('public')
-                ->path('api/app/'.$this->model()->id.'/resources')
+                ->path('api/app/' . $this->model()->id . '/resources')
                 ->storeAs(function () {
                     return 'logo_homepage.svg';
                 })
@@ -1201,7 +1202,7 @@ class App extends Resource
             Text::make('QR Code custom URL', 'qrcode_custom_url')
                 ->help(__('Customize the URL associated with the QR code, or leave empty for the default webapp URL')),
             Text::make('QR Code', 'qr_code', function () {
-                return "<div style='width:64px;height:64px; display:flex; align-items:center;'>".$this->qr_code.'</div>';
+                return "<div style='width:64px;height:64px; display:flex; align-items:center;'>" . $this->qr_code . '</div>';
             })
                 ->asHtml()
                 ->help(__('This field displays a QR code associated with this record. Ensure the QR code is clearly visible and scannable.')),
@@ -1240,7 +1241,7 @@ class App extends Resource
             Image::make(__('Icon'), 'icon')
                 ->rules('image', 'mimes:png', 'dimensions:width=1024,height=1024')
                 ->disk('public')
-                ->path('api/app/'.$this->model()->id.'/resources')
+                ->path('api/app/' . $this->model()->id . '/resources')
                 ->storeAs(function () {
                     return 'icon.png';
                 })
@@ -1249,7 +1250,7 @@ class App extends Resource
             Image::make(__('Splash image'), 'splash')
                 ->rules('image', 'mimes:png', 'dimensions:width=2732,height=2732')
                 ->disk('public')
-                ->path('api/app/'.$this->model()->id.'/resources')
+                ->path('api/app/' . $this->model()->id . '/resources')
                 ->storeAs(function () {
                     return 'splash.png';
                 })
@@ -1258,7 +1259,7 @@ class App extends Resource
             Image::make(__('Icon small'), 'icon_small')
                 ->rules('image', 'mimes:png', 'dimensions:width=512,height=512')
                 ->disk('public')
-                ->path('api/app/'.$this->model()->id.'/resources')
+                ->path('api/app/' . $this->model()->id . '/resources')
                 ->storeAs(function () {
                     return 'icon_small.png';
                 })
@@ -1291,13 +1292,13 @@ class App extends Resource
     {
         return [
             Text::make(__('API List'), function () {
-                return '<a class="btn btn-default btn-primary" href="/api/app/elbrus/'.$this->model()->id.'/config.json" target="_blank">Config</a>
-                <a class="btn btn-default btn-primary" href="/api/app/elbrus/'.$this->model()->id.'/taxonomies/activity.json" target="_blank">Activity</a>
-                    <a class="btn btn-default btn-primary" href="/api/app/elbrus/'.$this->model()->id.'/taxonomies/theme.json" target="_blank">Theme</a>
-                    <a class="btn btn-default btn-primary" href="/api/app/elbrus/'.$this->model()->id.'/taxonomies/when.json" target="_blank">When</a>
-                    <a class="btn btn-default btn-primary" href="/api/app/elbrus/'.$this->model()->id.'/taxonomies/where.json" target="_blank">Where</a>
-                    <a class="btn btn-default btn-primary" href="/api/app/elbrus/'.$this->model()->id.'/taxonomies/who.json" target="_blank">Target</a>
-                    <a class="btn btn-default btn-primary" href="/api/app/elbrus/'.$this->model()->id.'/taxonomies/webmapp_category.json" target="_blank">Webmapp Category</a>';
+                return '<a class="btn btn-default btn-primary" href="/api/app/elbrus/' . $this->model()->id . '/config.json" target="_blank">Config</a>
+                <a class="btn btn-default btn-primary" href="/api/app/elbrus/' . $this->model()->id . '/taxonomies/activity.json" target="_blank">Activity</a>
+                    <a class="btn btn-default btn-primary" href="/api/app/elbrus/' . $this->model()->id . '/taxonomies/theme.json" target="_blank">Theme</a>
+                    <a class="btn btn-default btn-primary" href="/api/app/elbrus/' . $this->model()->id . '/taxonomies/when.json" target="_blank">When</a>
+                    <a class="btn btn-default btn-primary" href="/api/app/elbrus/' . $this->model()->id . '/taxonomies/where.json" target="_blank">Where</a>
+                    <a class="btn btn-default btn-primary" href="/api/app/elbrus/' . $this->model()->id . '/taxonomies/who.json" target="_blank">Target</a>
+                    <a class="btn btn-default btn-primary" href="/api/app/elbrus/' . $this->model()->id . '/taxonomies/webmapp_category.json" target="_blank">Webmapp Category</a>';
             })->asHtml()->onlyOnDetail(),
             Text::make(__('API List (Tracks)'), function ($tracks) {
                 $tracks = \App\Models\EcTrack::where('user_id', $this->model()->user_id)->get();
@@ -1305,10 +1306,10 @@ class App extends Resource
                 foreach ($tracks as $track) {
                     $html .= '<div style="display:flex;margin-top:15px">';
                     $html .= '<div class="col-3">';
-                    $html .= '<a class="btn btn-default btn-primary mx-2" href="/api/app/elbrus/'.$this->model()->id.'/geojson/ec_track_'.$track->id.'.geojson">'.$track->name.'</a>';
+                    $html .= '<a class="btn btn-default btn-primary mx-2" href="/api/app/elbrus/' . $this->model()->id . '/geojson/ec_track_' . $track->id . '.geojson">' . $track->name . '</a>';
                     $html .= '</div>';
                     $html .= '<div class="col-3">';
-                    $html .= '<a class="btn btn-default btn-secondary mx-2" href="/resources/ec-tracks/'.$track->id.'/edit">Modifica Track</a>';
+                    $html .= '<a class="btn btn-default btn-secondary mx-2" href="/resources/ec-tracks/' . $track->id . '/edit">Modifica Track</a>';
                     $html .= '</div>';
                     $html .= '</div>';
                 }
@@ -1338,12 +1339,12 @@ class App extends Resource
                 if ($this->layers->count() > 0) {
                     $out = '';
                     foreach ($this->layers as $l) {
-                        $out .= '<a href="/resources/layers/'.$l->id.'">'.$l->name.'</a></br>';
+                        $out .= '<a href="/resources/layers/' . $l->id . '">' . $l->name . '</a></br>';
                     }
 
-                    return $out.$help;
+                    return $out . $help;
                 } else {
-                    return 'No Layers'.$help;
+                    return 'No Layers' . $help;
                 }
             })->asHtml(),
         ];
@@ -1361,12 +1362,12 @@ class App extends Resource
                 if ($this->overlayLayers->count() > 0) {
                     $out = '';
                     foreach ($this->overlayLayers as $l) {
-                        $out .= '<a href="/resources/overlay-layers/'.$l->id.'">'.$l->name.'</a></br>';
+                        $out .= '<a href="/resources/overlay-layers/' . $l->id . '">' . $l->name . '</a></br>';
                     }
 
-                    return $out.$help;
+                    return $out . $help;
                 } else {
-                    return 'No Overlay Layers'.$help;
+                    return 'No Overlay Layers' . $help;
                 }
             })->asHtml(),
         ];
@@ -1484,7 +1485,7 @@ class App extends Resource
                     ] 
                 }
             ]`)
-                ->help(__('This JSON structures the acquisition form for UGC POIs. Knowledge of JSON format required.').view('poi-forms')->render()),
+                ->help(__('This JSON structures the acquisition form for UGC POIs. Knowledge of JSON format required.') . view('poi-forms')->render()),
             Code::Make(__('TRACK acquisition forms'), 'track_acquisition_form')
                 ->language('json')
                 ->rules('json')
@@ -1594,7 +1595,7 @@ class App extends Resource
                     ] 
                 }
             ]`)
-                ->help(__('This JSON structures the acquisition form for UGC Tracks. Knowledge of JSON format required.').view('track-forms')->render()),
+                ->help(__('This JSON structures the acquisition form for UGC Tracks. Knowledge of JSON format required.') . view('track-forms')->render()),
         ];
     }
 
@@ -1641,7 +1642,7 @@ class App extends Resource
                 $collection = json_decode($mostviewedpois);
                 foreach ($collection->features as $count => $feature) {
                     $count++;
-                    $html .= '<tr><td style="width: 50%;">'.$count.' - '.$feature->properties->name.'</td><td style="width: 50%;"><strong>'.$feature->properties->visits.'</strong> visits</td></tr>';
+                    $html .= '<tr><td style="width: 50%;">' . $count . ' - ' . $feature->properties->name . '</td><td style="width: 50%;"><strong>' . $feature->properties->visits . '</strong> visits</td></tr>';
                 }
                 $html .= '</tbody></table>';
 
@@ -1715,8 +1716,8 @@ class App extends Resource
                     HTML;
 
                     foreach ($mediaIds as $mediaId) {
-                        $imageUrl = env('APP_URL').'/storage/media/images/ugc/image_'.$mediaId.'.jpg'; // Assuming 'media_ids' is the ID for the image
-                        $UgcMediaUrl = env('APP_URL').'/resources/ugc-medias/'.$mediaId;
+                        $imageUrl = env('APP_URL') . '/storage/media/images/ugc/image_' . $mediaId . '.jpg'; // Assuming 'media_ids' is the ID for the image
+                        $UgcMediaUrl = env('APP_URL') . '/resources/ugc-medias/' . $mediaId;
                         $html .= <<<HTML
                                 <div style="flex: 0 0 5%; text-align: center;">
                                     <a href="{$UgcMediaUrl}" target="_blank">


### PR DESCRIPTION
Added a new `AppZoom` enum to centralize the management of minimum and maximum zoom levels used across the application. Updated various instances in `App.php` to utilize these constants for better maintainability and consistency.

- Created `AppZoom` enum with `MIN_ZOOM` and `MAX_ZOOM` constants.
- Replaced hardcoded zoom level values in `App.php` with `AppZoom::MIN_ZOOM` and `AppZoom::MAX_ZOOM`.
- Improved string concatenation style for better readability.
