### PR TITLE
chore: make excerpt field nullable and expand limit oc: 6064

### DIFF
--- a/app/Nova/EcPoi.php
+++ b/app/Nova/EcPoi.php
@@ -437,6 +437,7 @@ class EcPoi extends Resource
                                 ->readonly($isOsmidSet)
                                 ->help(__($isOsmidSet ? 'This field is not editable because the OSM ID is already set.' : 'Displayed name of the POI.')),
                             Textarea::make(__('Excerpt'), 'excerpt')
+                                ->rules('nullable','max:255')
                                 ->help(_('Provide a brief summary or excerpt for the POI. This should be a concise description.')),
                             NovaWyswyg::make('Description')->canSee(function () use ($osmid) {
                                 return is_null($osmid);

--- a/database/migrations/2025_08_19_093436_change_excerpt_to_text_in_ec_pois.php
+++ b/database/migrations/2025_08_19_093436_change_excerpt_to_text_in_ec_pois.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class ChangeExcerptToTextInEcPois extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE ec_pois ALTER COLUMN excerpt TYPE TEXT USING excerpt::text');
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE ec_pois ALTER COLUMN excerpt TYPE VARCHAR(255)');
+    }
+}


### PR DESCRIPTION
Adds validation rule to allow null values for excerpt and extends maximum length to 255 characters. Introduces database migration to change column type to text for flexibility.

Ensures better handling of optional content in POI data.