### PR TITLE
feat(nova): ✨ add interactive map file format guidelines OC: 6161

### DIFF
--- a/app/Jobs/UpdateEcTrackAwsJob.php
+++ b/app/Jobs/UpdateEcTrackAwsJob.php
@@ -28,7 +28,7 @@ class UpdateEcTrackAwsJob implements ShouldQueue
     public function __construct($ecTrack)
     {
 
-        //TODO: we need reload ecTrack instance from database because some fields are not updated yet
+        // TODO: we need reload ecTrack instance from database because some fields are not updated yet
         $ecTrackId = $ecTrack->id;
         $ecTrack = EcTrack::find($ecTrackId);
         $this->ecTrack = $ecTrack;
@@ -42,7 +42,7 @@ class UpdateEcTrackAwsJob implements ShouldQueue
     public function handle()
     {
         $geojson = $this->ecTrack->getGeojson();
-        $trackUri = $this->ecTrack->id . '.json';
+        $trackUri = $this->ecTrack->id.'.json';
         try {
             Storage::disk('wmfetracks')->put($trackUri, json_encode($geojson));
         } catch (\Exception $e) {

--- a/app/Nova/EcTrack.php
+++ b/app/Nova/EcTrack.php
@@ -706,6 +706,17 @@ class EcTrack extends Resource
                 ],
             ]),
             new Panel('Map', [
+                Heading::make(
+                    <<<'HTML'
+                        <ul>
+                            <li><p><strong>Interactive Map File Format:</strong> Ensure that the uploaded file contains "LineString" geometry types for proper display in the interactive map.</p></li>
+                            <li><p><strong>Supported geometry type:</strong> <span style="color: #16a34a; font-family: monospace;">LineString</span> - Compatible format for map visualization.</p></li>
+                            <li><p><strong>NON compatible format:</strong> <span style="color: #dc2626; font-family: monospace;">MultiLineString</span> - Not supported and may cause visualization errors.</p></li>
+                            <li><p><strong>Documentation:</strong> <a href="https://drive.google.com/drive/folders/1ll0j-AAfp4aWPf1a3BWzMdI8BHC8X80F?usp=sharing" target="_blank" style="color: #2563eb; text-decoration: underline;">View complete documentation</a> for more details on supported formats.</p></li>
+                        </ul>
+                    HTML
+                )->asHtml()->onlyOnForms(),
+
                 MapMultiLinestringNova3::make(__('Map'), 'geometry')->withMeta([
                     'center' => ['51', '4'],
                     'attribution' => '<a href="https://webmapp.it/">Webmapp</a> contributors',


### PR DESCRIPTION
- Introduced a new informative heading to the 'Map' panel within `EcTrack` to guide users on the interactive map file format requirements.
- Detailed the supported and non-supported geometry types: emphasized "LineString" as compatible and "MultiLineString" as incompatible.
- Included a documentation link for users to access further details on supported formats.
