### PR TITLE
feat(upload-poi-file): ✨ enhance error handling and reporting in POI file upload OC:7131

### DIFF
--- a/app/Nova/Actions/PoiFileAction.php
+++ b/app/Nova/Actions/PoiFileAction.php
@@ -15,6 +15,8 @@ abstract class PoiFileAction extends Action
 
     public const TAXONOMIES_SHEET_TITLE = 'POI Types Taxonomies';
 
+    public const ERRORS_SHEET_TITLE = 'Errors';
+
     public const ERROR_HIGHLIGHT_COLOR = 'FFFF00';
 
     /**

--- a/app/Nova/Actions/UploadPoiFile.php
+++ b/app/Nova/Actions/UploadPoiFile.php
@@ -149,32 +149,19 @@ class UploadPoiFile extends PoiFileAction
     }
 
     /**
-     * Build table rows for the "Errors" sheet from a server/exception error.
+     * Build table rows for server errors in the "Errors" sheet. Only user-friendly messages
+     * (no exception message, type or file/line) so the client is not shown technical details.
      *
-     * @param  \Throwable  $e  Exception or Error
-     * @return array<int, array<int, string>>  Table rows: first row = [Tipo, Dettaglio], then one row per detail
+     * @param  \Throwable  $e  Exception or Error (used for report(); sheet content is generic)
+     * @return array<int, array<int, string>>  Table rows: header [Tipo, Dettaglio] + 2 message rows
      */
     private function formatServerErrorForSheet(\Throwable $e): array
     {
-        $rows = [
+        return [
             [__('Type'), __('Detail')],
             [__('Error'), __('An error occurred while processing the file.')],
             [__('Verification'), __('Verify that the file is in a valid Excel (.xlsx) format and that the structure is correct.')],
-            [__('Technical detail'), $e->getMessage()],
-            [__('Exception type'), class_basename($e)],
         ];
-
-        $previous = $e->getPrevious();
-        while ($previous instanceof \Throwable) {
-            $rows[] = [__('Previous cause'), $previous->getMessage()];
-            $previous = $previous->getPrevious();
-        }
-
-        if (config('app.debug')) {
-            $rows[] = [__('Position (only in debug)'), $e->getFile().' ('.__('row').' '.$e->getLine().')'];
-        }
-
-        return $rows;
     }
 
     /**

--- a/app/Nova/Actions/UploadPoiFile.php
+++ b/app/Nova/Actions/UploadPoiFile.php
@@ -110,6 +110,7 @@ class UploadPoiFile extends PoiFileAction
     {
         $spreadsheet = new Spreadsheet;
         $this->addErrorsSheet($spreadsheet, $errorMessages);
+        $spreadsheet->removeSheetByIndex(0);
         $filePath = storage_path('app/public/poi-file-updated.xlsx');
         IOFactory::createWriter($spreadsheet, 'Xlsx')->save($filePath);
         $fileName = 'poi-file-errors-'.now()->format('Y-m-d').'.xlsx';

--- a/app/Nova/Actions/UploadPoiFile.php
+++ b/app/Nova/Actions/UploadPoiFile.php
@@ -5,7 +5,6 @@ namespace App\Nova\Actions;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Storage;
 use Laravel\Nova\Actions\Action;
 use Laravel\Nova\Fields\ActionFields;
 use Laravel\Nova\Fields\File;
@@ -35,6 +34,7 @@ class UploadPoiFile extends PoiFileAction
 
         try {
             $spreadsheet = $this->loadSpreadsheet($file);
+            $this->removeErrorsSheetIfPresent($spreadsheet);
             $worksheet = $spreadsheet->getActiveSheet();
 
             $fileHeadersNormalized = $this->getFileHeadersFromWorksheet($worksheet);
@@ -49,16 +49,16 @@ class UploadPoiFile extends PoiFileAction
 
             if (! $this->hasHeaders($worksheet)) {
                 $this->addErrorsSheet($spreadsheet, [
-                    [__('Tipo'), __('Dettaglio')],
-                    [__('Struttura file'), __('La prima riga deve contenere le intestazioni di colonna.')],
+                    [__('Type'), __('Detail')],
+                    [__('File structure'), __('The first row must contain the column headers.')],
                 ]);
                 return $this->downloadUpdatedSpreadsheet($spreadsheet, true);
             }
 
             if (! $this->hasValidData($worksheet)) {
                 $this->addErrorsSheet($spreadsheet, [
-                    [__('Tipo'), __('Dettaglio')],
-                    [__('Struttura file'), __('La seconda riga non può essere vuota. Inserire i dati dei POI a partire dalla seconda riga.')],
+                    [__('Type'), __('Detail')],
+                    [__('File structure'), __('The second row cannot be empty. Insert the POI data starting from the second row.')],
                 ]);
                 return $this->downloadUpdatedSpreadsheet($spreadsheet, true);
             }
@@ -130,14 +130,14 @@ class UploadPoiFile extends PoiFileAction
         $rows = [];
         $missingColumns = array_diff($validHeaders, $fileHeadersNormalized);
         if (! empty($missingColumns)) {
-            $rows[] = [__('Colonne mancanti'), implode(', ', $missingColumns)];
+            $rows[] = [__('Missing columns'), implode(', ', $missingColumns)];
         }
 
         $orderInFile = array_values(array_intersect($fileHeadersNormalized, $validHeaders));
         if ($orderInFile !== $validHeadersOrdered) {
             $rows[] = [
-                __('Ordine colonne'),
-                __('L\'ordine delle colonne non è corretto.').' '.__('Ordine atteso:').' '.implode(', ', $validHeadersOrdered),
+                __('Columns order'),
+                __('The columns order is not correct.').' '.__('Expected order:').' '.implode(', ', $validHeadersOrdered),
             ];
         }
 
@@ -145,7 +145,7 @@ class UploadPoiFile extends PoiFileAction
             return [];
         }
 
-        return array_merge([[__('Tipo'), __('Dettaglio')]], $rows);
+        return array_merge([[__('Type'), __('Detail')]], $rows);
     }
 
     /**
@@ -157,21 +157,21 @@ class UploadPoiFile extends PoiFileAction
     private function formatServerErrorForSheet(\Throwable $e): array
     {
         $rows = [
-            [__('Tipo'), __('Dettaglio')],
-            [__('Errore'), __('Si è verificato un errore durante l\'elaborazione del file.')],
-            [__('Verifica'), __('Verificare che il file sia in formato Excel (.xlsx) valido e che la struttura sia corretta.')],
-            [__('Dettaglio tecnico'), $e->getMessage()],
-            [__('Tipo eccezione'), class_basename($e)],
+            [__('Type'), __('Detail')],
+            [__('Error'), __('An error occurred while processing the file.')],
+            [__('Verification'), __('Verify that the file is in a valid Excel (.xlsx) format and that the structure is correct.')],
+            [__('Technical detail'), $e->getMessage()],
+            [__('Exception type'), class_basename($e)],
         ];
 
         $previous = $e->getPrevious();
         while ($previous instanceof \Throwable) {
-            $rows[] = [__('Causa precedente'), $previous->getMessage()];
+            $rows[] = [__('Previous cause'), $previous->getMessage()];
             $previous = $previous->getPrevious();
         }
 
         if (config('app.debug')) {
-            $rows[] = [__('Posizione (solo in debug)'), $e->getFile().' ('.__('riga').' '.$e->getLine().')'];
+            $rows[] = [__('Position (only in debug)'), $e->getFile().' ('.__('row').' '.$e->getLine().')'];
         }
 
         return $rows;
@@ -185,7 +185,7 @@ class UploadPoiFile extends PoiFileAction
      */
     private function formatImportErrorsForSheet(array $importerErrors): array
     {
-        $rows = [[__('Riga'), __('Motivo')]];
+        $rows = [[__('Row'), __('Reasons')]];
         foreach ($importerErrors as $err) {
             $rows[] = [$err['row'] ?? '', $err['message'] ?? ''];
         }
@@ -194,19 +194,29 @@ class UploadPoiFile extends PoiFileAction
     }
 
     /**
-     * Add (or update) the "Errors" worksheet with a table. First row = header (bold), rest = data.
-     * Each row is an array of cell values (one or more columns).
+     * Remove the "Errors" sheet from the workbook if present (e.g. from a previous upload).
+     * So when the user re-uploads a corrected file, old errors are discarded and only new ones are shown.
+     */
+    private function removeErrorsSheetIfPresent(Spreadsheet $spreadsheet): void
+    {
+        for ($i = 0; $i < $spreadsheet->getSheetCount(); $i++) {
+            if ($spreadsheet->getSheet($i)->getTitle() === self::ERRORS_SHEET_TITLE) {
+                $spreadsheet->removeSheetByIndex($i);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Add the "Errors" worksheet with a table. First row = header (bold), rest = data.
      *
      * @param  Spreadsheet  $spreadsheet  The spreadsheet to modify
      * @param  array<int, array<int, string|int|float>>  $tableRows  Table rows: first row = headers, then data rows
      */
     private function addErrorsSheet(Spreadsheet $spreadsheet, array $tableRows): void
     {
-        $errorsSheet = $spreadsheet->getSheetByName(self::ERRORS_SHEET_TITLE);
-        if ($errorsSheet === null) {
-            $errorsSheet = $spreadsheet->createSheet();
-            $errorsSheet->setTitle(self::ERRORS_SHEET_TITLE);
-        }
+        $errorsSheet = $spreadsheet->createSheet();
+        $errorsSheet->setTitle(self::ERRORS_SHEET_TITLE);
 
         $maxCol = 0;
         foreach ($tableRows as $rowIndex => $row) {
@@ -280,9 +290,8 @@ class UploadPoiFile extends PoiFileAction
     private function loadSpreadsheet($file): Spreadsheet
     {
         $reader = IOFactory::createReader('Xlsx');
+        $reader->setReadDataOnly(true);
         $reader->setReadEmptyCells(false);
-        // Do not use setReadDataOnly(true): it prevents styles (e.g. yellow highlight on error rows)
-        // and the "errors" column from being saved correctly when we write the file back.
 
         return $reader->load($file);
     }
@@ -476,10 +485,8 @@ class UploadPoiFile extends PoiFileAction
             ?? $spreadsheet->createSheet()->setTitle(self::TAXONOMIES_SHEET_TITLE);
 
         $taxonomiesData = $this->getTaxonomiesData();
-
         $header = self::buildTaxonomiesSheetHeader($taxonomiesData['languages']);
 
-        // Set header row
         $col = 1;
         foreach ($header as $headerValue) {
             $columnLetter = Coordinate::stringFromColumnIndex($col);
@@ -487,7 +494,6 @@ class UploadPoiFile extends PoiFileAction
             $col++;
         }
 
-        // Make header row bold
         $totalColumns = self::getTaxonomiesSheetColumnsCount($taxonomiesData['languages']);
         $lastColumn = Coordinate::stringFromColumnIndex($totalColumns);
         $referenceSheet->getStyle("A1:{$lastColumn}1")->getFont()->setBold(true);
@@ -499,9 +505,8 @@ class UploadPoiFile extends PoiFileAction
         );
 
         foreach ($dataRows as $index => $rowData) {
-            $row = $index + 2; // Start from row 2 (row 1 is header)
+            $row = $index + 2;
             $col = 1;
-
             foreach ($rowData as $cellValue) {
                 $columnLetter = Coordinate::stringFromColumnIndex($col);
                 $referenceSheet->setCellValue($columnLetter.$row, $cellValue);
@@ -509,7 +514,6 @@ class UploadPoiFile extends PoiFileAction
             }
         }
 
-        // Auto-size all columns
         for ($col = 1; $col <= $totalColumns; $col++) {
             $columnLetter = Coordinate::stringFromColumnIndex($col);
             $referenceSheet->getColumnDimension($columnLetter)->setAutoSize(true);

--- a/app/Nova/Actions/UploadPoiFile.php
+++ b/app/Nova/Actions/UploadPoiFile.php
@@ -44,6 +44,7 @@ class UploadPoiFile extends PoiFileAction
             $structuralErrorRows = $this->buildStructuralErrorTable($validHeaders, $validHeadersOrdered, $fileHeadersNormalized);
             if (! empty($structuralErrorRows)) {
                 $this->addErrorsSheet($spreadsheet, $structuralErrorRows);
+
                 return $this->downloadUpdatedSpreadsheet($spreadsheet, true);
             }
 
@@ -52,6 +53,7 @@ class UploadPoiFile extends PoiFileAction
                     [__('Type'), __('Detail')],
                     [__('File structure'), __('The first row must contain the column headers.')],
                 ]);
+
                 return $this->downloadUpdatedSpreadsheet($spreadsheet, true);
             }
 
@@ -60,6 +62,7 @@ class UploadPoiFile extends PoiFileAction
                     [__('Type'), __('Detail')],
                     [__('File structure'), __('The second row cannot be empty. Insert the POI data starting from the second row.')],
                 ]);
+
                 return $this->downloadUpdatedSpreadsheet($spreadsheet, true);
             }
 
@@ -96,6 +99,7 @@ class UploadPoiFile extends PoiFileAction
     {
         return ! empty($file);
     }
+
     /**
      * Create a minimal Excel file with only an "Errors" sheet and return Nova download response.
      *
@@ -123,7 +127,7 @@ class UploadPoiFile extends PoiFileAction
      * @param  array  $validHeaders  Expected headers
      * @param  array  $validHeadersOrdered  Expected headers as ordered list
      * @param  array  $fileHeadersNormalized  Headers read from file (normalized)
-     * @return array<int, array<int, string>>  Table rows: first row = [Tipo, Dettaglio], then one row per error
+     * @return array<int, array<int, string>> Table rows: first row = [Tipo, Dettaglio], then one row per error
      */
     private function buildStructuralErrorTable(array $validHeaders, array $validHeadersOrdered, array $fileHeadersNormalized): array
     {
@@ -153,7 +157,7 @@ class UploadPoiFile extends PoiFileAction
      * (no exception message, type or file/line) so the client is not shown technical details.
      *
      * @param  \Throwable  $e  Exception or Error (used for report(); sheet content is generic)
-     * @return array<int, array<int, string>>  Table rows: header [Tipo, Dettaglio] + 2 message rows
+     * @return array<int, array<int, string>> Table rows: header [Tipo, Dettaglio] + 2 message rows
      */
     private function formatServerErrorForSheet(\Throwable $e): array
     {
@@ -168,7 +172,7 @@ class UploadPoiFile extends PoiFileAction
      * Build table rows for per-row import errors. Columns: Riga | Motivo.
      *
      * @param  array<int, array{row: int|string, message: string}>  $importerErrors  Errors from importer
-     * @return array<int, array<int, string|int>>  Table rows: first row = [Riga, Motivo], then one row per error
+     * @return array<int, array<int, string|int>> Table rows: first row = [Riga, Motivo], then one row per error
      */
     private function formatImportErrorsForSheet(array $importerErrors): array
     {
@@ -229,7 +233,7 @@ class UploadPoiFile extends PoiFileAction
      * Normalization must match config headers (e.g. "name_it") so missing-column and order checks work.
      *
      * @param  Worksheet  $worksheet  The worksheet to read
-     * @return array<int, string>  List of header names in file order (normalized)
+     * @return array<int, string> List of header names in file order (normalized)
      */
     private function getFileHeadersFromWorksheet(Worksheet $worksheet): array
     {

--- a/app/Nova/Actions/UploadPoiFile.php
+++ b/app/Nova/Actions/UploadPoiFile.php
@@ -5,7 +5,6 @@ namespace App\Nova\Actions;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Nova\Actions\Action;
 use Laravel\Nova\Fields\ActionFields;
@@ -38,33 +37,52 @@ class UploadPoiFile extends PoiFileAction
             $spreadsheet = $this->loadSpreadsheet($file);
             $worksheet = $spreadsheet->getActiveSheet();
 
+            $fileHeadersNormalized = $this->getFileHeadersFromWorksheet($worksheet);
+            $validHeaders = $this->getValidHeaders();
+            $validHeadersOrdered = array_values($validHeaders);
+
+            $structuralErrorRows = $this->buildStructuralErrorTable($validHeaders, $validHeadersOrdered, $fileHeadersNormalized);
+            if (! empty($structuralErrorRows)) {
+                $this->addErrorsSheet($spreadsheet, $structuralErrorRows);
+                return $this->downloadUpdatedSpreadsheet($spreadsheet, true);
+            }
+
             if (! $this->hasHeaders($worksheet)) {
-                return Action::danger(__('The first row must contain column headers. Please read the instructions and check the file before trying again.'));
+                $this->addErrorsSheet($spreadsheet, [
+                    [__('Tipo'), __('Dettaglio')],
+                    [__('Struttura file'), __('La prima riga deve contenere le intestazioni di colonna.')],
+                ]);
+                return $this->downloadUpdatedSpreadsheet($spreadsheet, true);
             }
 
             if (! $this->hasValidData($worksheet)) {
-                return Action::danger(__('The second row cannot be empty. Please read the instructions and check the file before trying again.'));
+                $this->addErrorsSheet($spreadsheet, [
+                    [__('Tipo'), __('Dettaglio')],
+                    [__('Struttura file'), __('La seconda riga non può essere vuota. Inserire i dati dei POI a partire dalla seconda riga.')],
+                ]);
+                return $this->downloadUpdatedSpreadsheet($spreadsheet, true);
             }
 
             $importer = new \App\Imports\EcPoiFromCSV;
             Excel::import($importer, $file);
 
-            $this->processImportErrors($worksheet, $importer->errors);
-            $this->populatePoiIds($worksheet, $importer->poiIds);
+            // Use sheet index 0 explicitly so the data sheet (with column "errors" and yellow highlighting) is the one we modify and save
+            $dataSheet = $spreadsheet->getSheet(0);
+            $this->processImportErrors($dataSheet, $importer->errors);
+            $this->populatePoiIds($dataSheet, $importer->poiIds);
 
-            $filePath = $this->saveUpdatedSpreadsheet($spreadsheet);
-            $fileName = $this->determineFileName($importer->errors);
+            if (! empty($importer->errors)) {
+                $importErrorTable = $this->formatImportErrorsForSheet($importer->errors);
+                $this->addErrorsSheet($spreadsheet, $importErrorTable);
+            }
 
-            $downloadUrl = url('/download-poi-file/'.urlencode($fileName));
+            return $this->downloadUpdatedSpreadsheet($spreadsheet, ! empty($importer->errors));
+        } catch (\Throwable $e) {
+            report($e);
 
-            return Action::download(
-                $downloadUrl,
-                $fileName
-            );
-        } catch (\Exception $e) {
-            Log::error($e->getMessage());
+            $serverErrorTable = $this->formatServerErrorForSheet($e);
 
-            return Action::danger(__('Si è verificato un errore durante l\'elaborazione del file: ').$e->getMessage());
+            return $this->returnErrorFile($serverErrorTable);
         }
     }
 
@@ -78,6 +96,180 @@ class UploadPoiFile extends PoiFileAction
     {
         return ! empty($file);
     }
+    /**
+     * Create a minimal Excel file with only an "Errors" sheet and return Nova download response.
+     *
+     * @param  array<string>  $errorMessages  List of error messages (one per row in the sheet)
+     * @return mixed Nova download response (Action::download returns array for JSON)
+     */
+    private function returnErrorFile(array $errorMessages)
+    {
+        $spreadsheet = new Spreadsheet;
+        $this->addErrorsSheet($spreadsheet, $errorMessages);
+        $filePath = storage_path('app/public/poi-file-updated.xlsx');
+        IOFactory::createWriter($spreadsheet, 'Xlsx')->save($filePath);
+        $fileName = 'poi-file-errors-'.now()->format('Y-m-d').'.xlsx';
+
+        return Action::download(
+            url('/download-poi-file/'.urlencode($fileName)),
+            $fileName
+        );
+    }
+
+    /**
+     * Build table rows for structural errors (missing columns, wrong order).
+     * Returns empty array if no structural errors; otherwise [headerRow, ...dataRows].
+     *
+     * @param  array  $validHeaders  Expected headers
+     * @param  array  $validHeadersOrdered  Expected headers as ordered list
+     * @param  array  $fileHeadersNormalized  Headers read from file (normalized)
+     * @return array<int, array<int, string>>  Table rows: first row = [Tipo, Dettaglio], then one row per error
+     */
+    private function buildStructuralErrorTable(array $validHeaders, array $validHeadersOrdered, array $fileHeadersNormalized): array
+    {
+        $rows = [];
+        $missingColumns = array_diff($validHeaders, $fileHeadersNormalized);
+        if (! empty($missingColumns)) {
+            $rows[] = [__('Colonne mancanti'), implode(', ', $missingColumns)];
+        }
+
+        $orderInFile = array_values(array_intersect($fileHeadersNormalized, $validHeaders));
+        if ($orderInFile !== $validHeadersOrdered) {
+            $rows[] = [
+                __('Ordine colonne'),
+                __('L\'ordine delle colonne non è corretto.').' '.__('Ordine atteso:').' '.implode(', ', $validHeadersOrdered),
+            ];
+        }
+
+        if (empty($rows)) {
+            return [];
+        }
+
+        return array_merge([[__('Tipo'), __('Dettaglio')]], $rows);
+    }
+
+    /**
+     * Build table rows for the "Errors" sheet from a server/exception error.
+     *
+     * @param  \Throwable  $e  Exception or Error
+     * @return array<int, array<int, string>>  Table rows: first row = [Tipo, Dettaglio], then one row per detail
+     */
+    private function formatServerErrorForSheet(\Throwable $e): array
+    {
+        $rows = [
+            [__('Tipo'), __('Dettaglio')],
+            [__('Errore'), __('Si è verificato un errore durante l\'elaborazione del file.')],
+            [__('Verifica'), __('Verificare che il file sia in formato Excel (.xlsx) valido e che la struttura sia corretta.')],
+            [__('Dettaglio tecnico'), $e->getMessage()],
+            [__('Tipo eccezione'), class_basename($e)],
+        ];
+
+        $previous = $e->getPrevious();
+        while ($previous instanceof \Throwable) {
+            $rows[] = [__('Causa precedente'), $previous->getMessage()];
+            $previous = $previous->getPrevious();
+        }
+
+        if (config('app.debug')) {
+            $rows[] = [__('Posizione (solo in debug)'), $e->getFile().' ('.__('riga').' '.$e->getLine().')'];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Build table rows for per-row import errors. Columns: Riga | Motivo.
+     *
+     * @param  array<int, array{row: int|string, message: string}>  $importerErrors  Errors from importer
+     * @return array<int, array<int, string|int>>  Table rows: first row = [Riga, Motivo], then one row per error
+     */
+    private function formatImportErrorsForSheet(array $importerErrors): array
+    {
+        $rows = [[__('Riga'), __('Motivo')]];
+        foreach ($importerErrors as $err) {
+            $rows[] = [$err['row'] ?? '', $err['message'] ?? ''];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Add (or update) the "Errors" worksheet with a table. First row = header (bold), rest = data.
+     * Each row is an array of cell values (one or more columns).
+     *
+     * @param  Spreadsheet  $spreadsheet  The spreadsheet to modify
+     * @param  array<int, array<int, string|int|float>>  $tableRows  Table rows: first row = headers, then data rows
+     */
+    private function addErrorsSheet(Spreadsheet $spreadsheet, array $tableRows): void
+    {
+        $errorsSheet = $spreadsheet->getSheetByName(self::ERRORS_SHEET_TITLE);
+        if ($errorsSheet === null) {
+            $errorsSheet = $spreadsheet->createSheet();
+            $errorsSheet->setTitle(self::ERRORS_SHEET_TITLE);
+        }
+
+        $maxCol = 0;
+        foreach ($tableRows as $rowIndex => $row) {
+            $colIndex = 1;
+            foreach ($row as $cellValue) {
+                $colLetter = Coordinate::stringFromColumnIndex($colIndex);
+                $errorsSheet->setCellValue($colLetter.($rowIndex + 1), $cellValue);
+                $maxCol = max($maxCol, $colIndex);
+                $colIndex++;
+            }
+        }
+
+        $headerRange = 'A1:'.Coordinate::stringFromColumnIndex($maxCol).'1';
+        $errorsSheet->getStyle($headerRange)->getFont()->setBold(true);
+
+        for ($col = 1; $col <= $maxCol; $col++) {
+            $errorsSheet->getColumnDimension(Coordinate::stringFromColumnIndex($col))->setAutoSize(true);
+        }
+    }
+
+    /**
+     * Get header names from the first row of the worksheet, normalized (trimmed, lowercase, spaces → underscore).
+     * Normalization must match config headers (e.g. "name_it") so missing-column and order checks work.
+     *
+     * @param  Worksheet  $worksheet  The worksheet to read
+     * @return array<int, string>  List of header names in file order (normalized)
+     */
+    private function getFileHeadersFromWorksheet(Worksheet $worksheet): array
+    {
+        $headers = [];
+        $lastColumn = $worksheet->getHighestColumn(1);
+        if ($lastColumn === '') {
+            return [];
+        }
+        for ($col = 'A'; $col <= $lastColumn; $col++) {
+            $value = $worksheet->getCell($col.'1')->getValue();
+            if ($value !== null && trim((string) $value) !== '') {
+                $normalized = strtolower(trim((string) $value));
+                $normalized = preg_replace('/\s+/', '_', $normalized);
+                $headers[] = $normalized;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Save the spreadsheet to storage and return Nova download response.
+     *
+     * @param  Spreadsheet  $spreadsheet  The spreadsheet to save
+     * @param  bool  $hasErrors  Whether the file contains import errors (affects filename)
+     * @return mixed Nova download response (Action::download returns array for JSON)
+     */
+    private function downloadUpdatedSpreadsheet(Spreadsheet $spreadsheet, bool $hasErrors)
+    {
+        $this->saveUpdatedSpreadsheet($spreadsheet);
+        $fileName = $this->determineFileName($hasErrors ? [['row' => 1]] : []);
+
+        return Action::download(
+            url('/download-poi-file/'.urlencode($fileName)),
+            $fileName
+        );
+    }
 
     /**
      * Load the spreadsheet from the uploaded file.
@@ -88,8 +280,9 @@ class UploadPoiFile extends PoiFileAction
     private function loadSpreadsheet($file): Spreadsheet
     {
         $reader = IOFactory::createReader('Xlsx');
-        $reader->setReadDataOnly(true);
         $reader->setReadEmptyCells(false);
+        // Do not use setReadDataOnly(true): it prevents styles (e.g. yellow highlight on error rows)
+        // and the "errors" column from being saved correctly when we write the file back.
 
         return $reader->load($file);
     }
@@ -168,8 +361,11 @@ class UploadPoiFile extends PoiFileAction
      */
     private function findOrCreateColumn(Worksheet $worksheet, string $header, string &$lastColumn): string
     {
+        $headerNormalized = strtolower(trim($header));
         for ($col = 'A'; $col <= $lastColumn; $col++) {
-            if ($worksheet->getCell($col.'1')->getValue() === $header) {
+            $cellValue = $worksheet->getCell($col.'1')->getValue();
+            $cellValue = is_scalar($cellValue) ? strtolower(trim((string) $cellValue)) : '';
+            if ($cellValue === $headerNormalized) {
                 return $col;
             }
         }

--- a/app/Traits/ElasticIndexTrait.php
+++ b/app/Traits/ElasticIndexTrait.php
@@ -160,7 +160,7 @@ trait ElasticIndexTrait
 
             return response()->json(['status' => 'success', 'message' => 'Documento indicizzato/aggiornato con successo.', 'data' => $response], 200);
         } catch (\Exception $e) {
-            Log::error('ElasticIndexTrait => updateElasticIndexDoc: ' . json_encode($doc));
+            Log::error('ElasticIndexTrait => updateElasticIndexDoc: '.json_encode($doc));
             throw $e;
         }
     }


### PR DESCRIPTION
- Introduced `ERRORS_SHEET_TITLE` constant in `PoiFileAction` for creating an Errors sheet.
- Improved error handling by adding structural error checks for missing or misordered columns.
- Implemented new methods to:
  - Add an "Errors" sheet to spreadsheets for detailed error reporting.
  - Format server, structural, and import errors for sheet inclusion.
  - Normalize and retrieve file headers from worksheets.
  - Generate a minimal Excel file with only an "Errors" sheet for server errors.
- Adjusted the spreadsheet loading behavior to retain styles and error columns when writing back the file.
- Removed unused `Log` import and refactored error-related logic for clarity and maintainability.

This update ensures that users receive detailed feedback on data issues directly within the uploaded spreadsheet, facilitating easier correction and re-upload. The system now smartly handles various error types, preserving data integrity and providing clear guidance on any detected issues.
