### PR TITLE
feat(EcPoi): ✨ add taxonomyWhere property with sorted admin_level oc:7313

### DIFF
--- a/app/Models/EcPoi.php
+++ b/app/Models/EcPoi.php
@@ -324,6 +324,18 @@ class EcPoi extends Model
         // TODO non so se modificare taxonomy rompe qualcosa per ora ho inseritono una nuova proprietà
         $array['taxonomyIdentifiers'] = $taxonomiesidentifiers;
 
+        // taxonomyWhere: elenco dei where associati al POI, ordinato per admin_level come in TrackElasticIndexTrait::getTaxonomyWheres
+        if ($this->taxonomyWheres->count() > 0) {
+            $sortedTaxonomyWheres = $this->taxonomyWheres
+                ->filter(function ($item) {
+                    return ! is_null($item->admin_level);
+                })
+                ->sortBy(function ($item) {
+                    return (int) $item->admin_level;
+                });
+            $array['taxonomyWhere'] = $sortedTaxonomyWheres->pluck('name')->toArray();
+        }
+
         $propertiesToClear = ['geometry'];
         foreach ($array as $property => $value) {
             if (

--- a/app/Models/EcPoi.php
+++ b/app/Models/EcPoi.php
@@ -333,7 +333,7 @@ class EcPoi extends Model
                 ->sortBy(function ($item) {
                     return (int) $item->admin_level;
                 });
-            $array['taxonomyWhere'] = $sortedTaxonomyWheres->pluck('name')->toArray();
+            $array['taxonomyWheres'] = $sortedTaxonomyWheres->pluck('name')->toArray();
         }
 
         $propertiesToClear = ['geometry'];

--- a/app/Models/EcTrack.php
+++ b/app/Models/EcTrack.php
@@ -372,6 +372,17 @@ class EcTrack extends Model
 
         $array['taxonomy'] = $taxonomies;
 
+        if ($this->taxonomyWheres->count() > 0) {
+            $sortedTaxonomyWheres = $this->taxonomyWheres
+                ->filter(function ($item) {
+                    return ! is_null($item->admin_level);
+                })
+                ->sortBy(function ($item) {
+                    return (int) $item->admin_level;
+                });
+            $array['taxonomyWheres'] = $sortedTaxonomyWheres->pluck('name')->toArray();
+        }
+
         $durations = [];
         $activityTerms = $this->taxonomyActivities()->whereIn('identifier', ['hiking', 'cycling'])->get()->toArray();
         if (count($activityTerms) > 0) {

--- a/app/Nova/Filters/SchemaFilter.php
+++ b/app/Nova/Filters/SchemaFilter.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
 
- // Importa il modello App se non già fatto
+// Importa il modello App se non già fatto
 
 class SchemaFilter extends Filter
 {


### PR DESCRIPTION
- Introduced a new property `taxonomyWhere` in the `EcPoi` model to store associated taxonomy conditions, sorted by `admin_level`.
- Implemented filtering to exclude null `admin_level` values and ensure proper ordering of taxonomy conditions.
- This enhancement improves the organization of taxonomy-related data for better processing and retrieval.
