### PR TITLE
feat(commands): ✨ add support for GeoJSON processing and workbook export OC:7774

### DIFF
--- a/app/Console/Commands/ApplyReerUpdatesFromWorkbookCommand.php
+++ b/app/Console/Commands/ApplyReerUpdatesFromWorkbookCommand.php
@@ -128,6 +128,7 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
             $trackId = $this->parseTrackId($idRaw);
             if ($trackId === null) {
                 $this->warn('Riga '.($idx + 2).': ID_GEOHUB non valido, skip.');
+
                 continue;
             }
             $kmz = ($colIndex['kmz'] !== null) ? trim((string) ($row[$colIndex['kmz']] ?? '')) : '';

--- a/app/Console/Commands/ApplyReerUpdatesFromWorkbookCommand.php
+++ b/app/Console/Commands/ApplyReerUpdatesFromWorkbookCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Console\Concerns\StreamsReerGeoJsonFeatures;
 use App\Jobs\GeneratePBFByTrackJob;
 use App\Jobs\UpdateCurrentDataJob;
 use App\Jobs\UpdateEcTrack3DDemJob;
@@ -16,39 +17,68 @@ use App\Jobs\UpdateManualDataJob;
 use App\Jobs\UpdateModelWithGeometryTaxonomyWhere;
 use App\Jobs\UpdateTrackPBFInfoJob;
 use App\Models\EcTrack;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use RuntimeException;
 use Throwable;
 use ZipArchive;
 
 /**
- * Applica geometrie REER (KMZ ufficiale) alle sole tracce GeoHub marcate
- * "presente da aggiornare" nel workbook prodotto da geohub:compare-reer (foglio Tracce).
+ * Applica geometrie alle tracce GeoHub marcate "presente da aggiornare" nel workbook
+ * generato da geohub:compare-reer. Fonte geometria consigliata: stesso GeoJSON REER
+ * usato nel confronto (--geojson); in alternativa download da REER_KMZ (KMZ ArcGIS).
  */
 class ApplyReerUpdatesFromWorkbookCommand extends Command
 {
+    use StreamsReerGeoJsonFeatures;
+
     private const STATUS_UPDATE = 'presente da aggiornare';
 
+    private const STATUS_UPDATED = 'presente e aggiornato';
+
+    private const SHEET_SUMMARY = 'Riepilogo';
+
     protected $signature = 'geohub:apply-reer-from-workbook
-        {workbook : Percorso assoluto al file .xlsx (es. export da Google Sheets)}
+        {workbook : Percorso al file .xlsx (es. export da Google Sheets o storage/app/...)}
         {--sheet=Tracce : Nome del foglio con colonne ID_GEOHUB, REER_CHECK, REER_KMZ}
+        {--geojson= : Stesso GeoJSON REER usato in compare-reer (consigliato: geometrie da file)}
         {--dry-run : Elenca le righe da aggiornare senza modificare il database}
         {--limit=0 : Elabora al massimo N tracce (0 = tutte)}
         {--timeout=120 : Timeout HTTP in secondi per scaricare ogni KMZ}
+        {--post-apply-output= : Workbook di uscita (default: storage/app/reer_report_post_apply_<data>.xlsx)}
+        {--no-post-export : Non scrivere il workbook dopo l\'apply (solo DB + job)}
     ';
 
-    protected $description = 'Allinea la geometria delle tracce GeoHub al REER (KMZ) solo per righe "presente da aggiornare" nel workbook';
+    protected $description = 'Applica geometria REER sulle tracce "presente da aggiornare" (GeoJSON e/o KMZ) e salva il report aggiornato';
 
     public function handle(): int
     {
-        $path = (string) $this->argument('workbook');
+        $path = $this->resolvePath((string) $this->argument('workbook'));
         $sheetName = (string) $this->option('sheet');
+        $geojsonOpt = $this->option('geojson');
+        $geojsonPath = is_string($geojsonOpt) && $geojsonOpt !== ''
+            ? $this->resolvePath($geojsonOpt)
+            : '';
         $dryRun = (bool) $this->option('dry-run');
         $limit = max(0, (int) $this->option('limit'));
         $timeout = max(5, (int) $this->option('timeout'));
+        $noPostExport = (bool) $this->option('no-post-export');
+        $postApplyOutputOpt = $this->option('post-apply-output');
+        $postApplyOutput = is_string($postApplyOutputOpt) && $postApplyOutputOpt !== ''
+            ? $this->resolvePath($postApplyOutputOpt)
+            : storage_path('app/reer_report_post_apply_'.Carbon::now()->format('Ymd_His').'.xlsx');
+
+        if ($geojsonPath !== '' && ! is_readable($geojsonPath)) {
+            $this->error("File GeoJSON non leggibile: {$geojsonPath}");
+
+            return 1;
+        }
 
         if (! is_readable($path)) {
             $this->error("File non leggibile: {$path}");
@@ -74,9 +104,15 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
         }
 
         $header = array_shift($rows);
-        $colIndex = $this->mapHeaderRow($header);
-        if ($colIndex['id'] === null || $colIndex['check'] === null || $colIndex['kmz'] === null) {
-            $this->error('Intestazioni attese: ID_GEOHUB, REER_CHECK, REER_KMZ (opzionale LINK_EDIT_GEOHUB). Trovato: '.json_encode($header));
+        $colIndex = $this->resolveTracceColumnIndexes($header, $rows);
+        $useGeojson = $geojsonPath !== '';
+        if ($colIndex['id'] === null || $colIndex['check'] === null) {
+            $this->error('Intestazioni attese: ID_GEOHUB, REER_CHECK (e REER_KMZ se non usi --geojson). Trovato: '.json_encode($header));
+
+            return 1;
+        }
+        if (! $useGeojson && $colIndex['kmz'] === null) {
+            $this->error('Colonna REER_KMZ richiesta senza --geojson, oppure passa --geojson= per usare le geometrie dal file ufficiale.');
 
             return 1;
         }
@@ -94,12 +130,33 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
                 $this->warn('Riga '.($idx + 2).': ID_GEOHUB non valido, skip.');
                 continue;
             }
-            $kmz = $colIndex['kmz'] !== null ? trim((string) ($row[$colIndex['kmz']] ?? '')) : '';
-            if ($kmz === '' || ! filter_var($kmz, FILTER_VALIDATE_URL)) {
-                $this->warn("Traccia {$trackId}: REER_KMZ assente o URL non valido, skip.");
-                continue;
+            $kmz = ($colIndex['kmz'] !== null) ? trim((string) ($row[$colIndex['kmz']] ?? '')) : '';
+            $idPercorsoCell = ($colIndex['id_percorso'] !== null) ? trim((string) ($row[$colIndex['id_percorso']] ?? '')) : '';
+            $idPercorso = $idPercorsoCell !== '' ? $idPercorsoCell : $this->parseIdPercorsoFromKmzUrl($kmz);
+            if ($idPercorso !== null) {
+                $idPercorso = trim($idPercorso);
+            } else {
+                $idPercorso = '';
             }
-            $candidates[] = ['track_id' => $trackId, 'kmz' => $kmz];
+
+            if ($useGeojson) {
+                if ($idPercorso === '') {
+                    $this->warn("Traccia {$trackId}: impossibile ricavare ID percorso REER dall'URL REER_KMZ (serve con --geojson), skip.");
+
+                    continue;
+                }
+                if ($kmz !== '' && ! filter_var($kmz, FILTER_VALIDATE_URL)) {
+                    $this->warn("Traccia {$trackId}: REER_KMZ non URL valido (si usa solo GeoJSON).");
+                }
+            } else {
+                if ($kmz === '' || ! filter_var($kmz, FILTER_VALIDATE_URL)) {
+                    $this->warn("Traccia {$trackId}: REER_KMZ assente o URL non valido, skip.");
+
+                    continue;
+                }
+            }
+
+            $candidates[] = ['track_id' => $trackId, 'kmz' => $kmz, 'id_percorso' => $idPercorso];
         }
 
         $total = count($candidates);
@@ -107,15 +164,30 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
             $candidates = array_slice($candidates, 0, $limit);
         }
 
-        $this->info('Righe "presente da aggiornare" con KMZ valido: '.$total.' (elaboro: '.count($candidates).')');
+        $sourceNote = $useGeojson
+            ? " (--geojson: {$geojsonPath})"
+            : ' (solo KMZ)';
+        $this->info('Righe "presente da aggiornare" da elaborare: '.$total.' (eseguo: '.count($candidates).')'.$sourceNote);
 
         if ($candidates === []) {
             return 0;
         }
 
+        $geomIndex = [];
+        if ($useGeojson && $candidates !== []) {
+            $needed = [];
+            foreach ($candidates as $c) {
+                $needed[strtolower($c['id_percorso'])] = true;
+            }
+            $geomIndex = $this->loadReerGeometriesByIdPercorso($geojsonPath, $needed);
+            $this->info('Geometrie caricate dal GeoJSON per ID_PERCORSO richiesti: '.count($geomIndex));
+        }
+
         if ($dryRun) {
             foreach ($candidates as $c) {
-                $this->line("[dry-run] track_id={$c['track_id']} kmz={$c['kmz']}");
+                $ip = $c['id_percorso'];
+                $kmz = $c['kmz'];
+                $this->line("[dry-run] track_id={$c['track_id']} id_percorso={$ip} kmz={$kmz}");
             }
             $this->info('Nessuna modifica (dry-run).');
 
@@ -124,17 +196,12 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
 
         $ok = 0;
         $fail = 0;
+        /** @var list<int> */
+        $successfulTrackIds = [];
         foreach ($candidates as $c) {
             $trackId = $c['track_id'];
             $kmzUrl = $c['kmz'];
             try {
-                $payload = $this->fetchKmlOrRawXml($kmzUrl, $timeout);
-                if ($payload === null || $payload === '') {
-                    $this->error("Traccia {$trackId}: download KMZ/KML fallito o archivio non valido.");
-                    $fail++;
-
-                    continue;
-                }
                 $track = EcTrack::query()->find($trackId);
                 if (! $track) {
                     $this->error("Traccia {$trackId}: non trovata.");
@@ -142,9 +209,28 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
 
                     continue;
                 }
-                $geometry = $track->fileToGeometry($payload);
+
+                $geometry = null;
+                if ($useGeojson && $c['id_percorso'] !== '') {
+                    $gKey = strtolower($c['id_percorso']);
+                    if (isset($geomIndex[$gKey])) {
+                        $geometry = $this->geometryRawFromGeoJson($geomIndex[$gKey]);
+                    }
+                }
+
+                if ($geometry === null && $kmzUrl !== '') {
+                    $payload = $this->fetchKmlOrRawXml($kmzUrl, $timeout);
+                    if ($payload === null || $payload === '') {
+                        $this->error("Traccia {$trackId}: download KMZ/KML fallito o archivio non valido.");
+                        $fail++;
+
+                        continue;
+                    }
+                    $geometry = $track->fileToGeometry($payload);
+                }
+
                 if ($geometry === null) {
-                    $this->error("Traccia {$trackId}: impossibile derivare la geometria dal file REER.");
+                    $this->error("Traccia {$trackId}: impossibile ottenere la geometria (GeoJSON/KMZ).");
                     $fail++;
 
                     continue;
@@ -159,10 +245,27 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
                 $this->dispatchGeometryFollowUpChain($track);
                 $this->info("Traccia {$trackId}: geometria aggiornata da REER (code post-processing accodati).");
                 $ok++;
+                $successfulTrackIds[] = $trackId;
             } catch (Throwable $e) {
                 Log::error('geohub:apply-reer-from-workbook track '.$trackId.': '.$e->getMessage(), ['e' => $e]);
                 $this->error("Traccia {$trackId}: ".$e->getMessage());
                 $fail++;
+            }
+        }
+
+        if (! $noPostExport && $successfulTrackIds !== []) {
+            try {
+                $changed = $this->writePostApplyWorkbook($path, $postApplyOutput, $sheetName, $successfulTrackIds);
+                $this->info("Workbook post-apply salvato ({$changed} righe aggiornate in colonna REER_CHECK): {$postApplyOutput}");
+                if ($fail > 0) {
+                    $this->warn("Apply parziale: nel workbook restano \"presente da aggiornare\" le tracce non riuscite (errori={$fail}).");
+                }
+            } catch (Throwable $e) {
+                Log::error('geohub:apply-reer-from-workbook post-export: '.$e->getMessage(), ['e' => $e]);
+                $this->error('Export workbook post-apply fallito: '.$e->getMessage());
+                $this->warn('Le tracce sono state aggiornate su GeoHub; correggi il report Excel a mano o usa geohub:export-reer-workbook-post-apply.');
+
+                return 1;
             }
         }
 
@@ -172,8 +275,185 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
     }
 
     /**
+     * Gestisce workbook legacy con 5 colonne dati (id, uuid, link, stato, kmz) ma intestazione
+     * a 4 etichette senza colonna dedicata allo UUID: le etichette risultano sfalsate.
+     *
      * @param  list<mixed>  $headerRow
-     * @return array{id: int|null, check: int|null, kmz: int|null}
+     * @param  array<int, list<mixed>>  $dataRows
+     * @return array{id: int|null, id_percorso: int|null, check: int|null, kmz: int|null}
+     */
+    private function resolveTracceColumnIndexes(array $headerRow, array $dataRows): array
+    {
+        $colIndex = $this->mapHeaderRow($headerRow);
+        if ($colIndex['id'] === null || $colIndex['check'] === null) {
+            return $colIndex;
+        }
+        if ($colIndex['id_percorso'] !== null) {
+            return $colIndex;
+        }
+        $probeCol = $colIndex['check'];
+        foreach ($dataRows as $row) {
+            $atProbe = isset($row[$probeCol]) ? trim((string) $row[$probeCol]) : '';
+            $at3 = isset($row[3]) ? trim((string) $row[3]) : '';
+            $at4 = isset($row[4]) ? trim((string) $row[4]) : '';
+            if ($atProbe !== '' && strpos($atProbe, 'http') === 0
+                && $at3 !== '' && (stripos($at3, 'presente') !== false || stripos($at3, 'assente') !== false)
+                && $at4 !== '' && strpos($at4, 'http') === 0) {
+                $this->warn('Layout foglio Tracce: file Excel a 5 colonne con intestazioni vecchie (sfasamento) — uso stato col. 4 e KMZ col. 5. Rigenera il report con compare-reer per avere 4 colonne allineate.');
+
+                return [
+                    'id' => 0,
+                    'id_percorso' => 1,
+                    'check' => 3,
+                    'kmz' => 4,
+                ];
+            }
+        }
+
+        return $colIndex;
+    }
+
+    private function resolvePath(string $path): string
+    {
+        if ($path !== '' && $path[0] === DIRECTORY_SEPARATOR) {
+            return $path;
+        }
+
+        return base_path($path);
+    }
+
+    /**
+     * @param  list<int>  $successfulTrackIds
+     */
+    private function writePostApplyWorkbook(
+        string $sourcePath,
+        string $outputPath,
+        string $sheetName,
+        array $successfulTrackIds
+    ): int {
+        $successSet = [];
+        foreach ($successfulTrackIds as $id) {
+            $successSet[(int) $id] = true;
+        }
+
+        $spreadsheet = IOFactory::load($sourcePath);
+        $sheet = $spreadsheet->getSheetByName($sheetName);
+        if (! $sheet) {
+            throw new RuntimeException("Foglio non trovato: {$sheetName}");
+        }
+
+        $rows = $sheet->toArray();
+        if ($rows === []) {
+            return 0;
+        }
+        $header = array_shift($rows);
+        $colIndex = $this->resolveTracceColumnIndexes($header, $rows);
+        if ($colIndex['id'] === null || $colIndex['check'] === null) {
+            throw new RuntimeException('Intestazioni attese: ID_GEOHUB, REER_CHECK nel foglio tracce.');
+        }
+
+        $changed = 0;
+        foreach ($rows as $idx => $row) {
+            $trackId = $this->parseTrackId($row[$colIndex['id']] ?? null);
+            if ($trackId === null || ! isset($successSet[$trackId])) {
+                continue;
+            }
+            $checkNorm = $this->normalizeStatus($row[$colIndex['check']] ?? null);
+            if ($checkNorm !== self::STATUS_UPDATE) {
+                continue;
+            }
+            $sheet->setCellValueByColumnAndRow($colIndex['check'] + 1, $idx + 2, self::STATUS_UPDATED);
+            $changed++;
+        }
+
+        $this->updateSummarySheet($spreadsheet, $changed);
+
+        $writer = IOFactory::createWriter($spreadsheet, 'Xlsx');
+        $writer->save($outputPath);
+
+        return $changed;
+    }
+
+    private function updateSummarySheet(Spreadsheet $spreadsheet, int $changed): void
+    {
+        if ($changed <= 0) {
+            return;
+        }
+        $summary = $spreadsheet->getSheetByName(self::SHEET_SUMMARY);
+        if (! $summary) {
+            return;
+        }
+
+        $dataRow = Carbon::now()->timezone(config('app.timezone'))->toIso8601String();
+        $rows = $summary->toArray();
+        foreach ($rows as $rowIdx => $row) {
+            $key = isset($row[0]) ? trim((string) $row[0]) : '';
+            if ($key === 'Data') {
+                $summary->setCellValueByColumnAndRow(2, $rowIdx + 1, $dataRow);
+            }
+            if ($key === self::STATUS_UPDATED) {
+                $prev = isset($row[1]) ? (int) $row[1] : 0;
+                $summary->setCellValueByColumnAndRow(2, $rowIdx + 1, $prev + $changed);
+            }
+            if ($key === self::STATUS_UPDATE) {
+                $prev = isset($row[1]) ? (int) $row[1] : 0;
+                $summary->setCellValueByColumnAndRow(2, $rowIdx + 1, max(0, $prev - $changed));
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, bool>  $neededLowercaseIds
+     * @return array<string, array<string, mixed>>
+     */
+    private function loadReerGeometriesByIdPercorso(string $geojsonPath, array $neededLowercaseIds): array
+    {
+        $index = [];
+        foreach ($this->streamReerGeoJsonFeatures($geojsonPath) as $feature) {
+            $props = $feature['properties'] ?? null;
+            $geom = $feature['geometry'] ?? null;
+            if (! is_array($props) || ! is_array($geom)) {
+                continue;
+            }
+            $idPercorso = $props['ID_PERCORSO'] ?? null;
+            if (! is_string($idPercorso) || trim($idPercorso) === '') {
+                continue;
+            }
+            $key = strtolower(trim($idPercorso));
+            if (! isset($neededLowercaseIds[$key])) {
+                continue;
+            }
+            $index[$key] = $geom;
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param  array<string, mixed>  $geometry
+     * @return \Illuminate\Database\Query\Expression
+     */
+    private function geometryRawFromGeoJson(array $geometry)
+    {
+        return DB::raw("(ST_Force3D(ST_GeomFromGeoJSON('".json_encode($geometry)."')))");
+    }
+
+    private function parseIdPercorsoFromKmzUrl(string $url): ?string
+    {
+        if (preg_match('/ID_PERCORSO%3D%27([^%\'\s]+)%27/i', $url, $m)) {
+            return rawurldecode($m[1]);
+        }
+        $decoded = rawurldecode($url);
+        if (preg_match("/ID_PERCORSO\\s*=\\s*'([^']+)'/i", $decoded, $m)) {
+            return trim($m[1]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<mixed>  $headerRow
+     * @return array{id: int|null, id_percorso: int|null, check: int|null, kmz: int|null}
      */
     private function mapHeaderRow(array $headerRow): array
     {
@@ -187,22 +467,30 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
 
         return [
             'id' => $map['id_geohub'] ?? null,
+            'id_percorso' => $map['id_percorso'] ?? null,
             'check' => $map['reer_check'] ?? null,
             'kmz' => $map['reer_kmz'] ?? null,
         ];
     }
 
-    private function normalizeStatus(mixed $value): string
+    /**
+     * @param  mixed  $value
+     */
+    private function normalizeStatus($value): string
     {
         $s = strtolower(trim((string) $value));
+        $collapsed = preg_replace('/[\s_-]+/u', ' ', $s);
+        if ($collapsed === 'presente da aggiornare') {
+            return self::STATUS_UPDATE;
+        }
 
-        return match ($s) {
-            'presente da aggiornare', 'presente_da_aggiornare' => self::STATUS_UPDATE,
-            default => $s,
-        };
+        return $s;
     }
 
-    private function parseTrackId(mixed $value): ?int
+    /**
+     * @param  mixed  $value
+     */
+    private function parseTrackId($value): ?int
     {
         if ($value === null || $value === '') {
             return null;
@@ -227,7 +515,7 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
         }
         $body = $response->body();
         $trim = ltrim($body);
-        if (str_starts_with($trim, '<?xml') || str_starts_with($trim, '<kml')) {
+        if (strpos($trim, '<?xml') === 0 || strpos($trim, '<kml') === 0) {
             return $body;
         }
 

--- a/app/Console/Commands/ApplyReerUpdatesFromWorkbookCommand.php
+++ b/app/Console/Commands/ApplyReerUpdatesFromWorkbookCommand.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\GeneratePBFByTrackJob;
+use App\Jobs\UpdateCurrentDataJob;
+use App\Jobs\UpdateEcTrack3DDemJob;
+use App\Jobs\UpdateEcTrackAwsJob;
+use App\Jobs\UpdateEcTrackDemJob;
+use App\Jobs\UpdateEcTrackElasticIndexJob;
+use App\Jobs\UpdateEcTrackGenerateElevationChartImage;
+use App\Jobs\UpdateEcTrackOrderRelatedPoi;
+use App\Jobs\UpdateEcTrackSlopeValues;
+use App\Jobs\UpdateLayerTracksJob;
+use App\Jobs\UpdateManualDataJob;
+use App\Jobs\UpdateModelWithGeometryTaxonomyWhere;
+use App\Jobs\UpdateTrackPBFInfoJob;
+use App\Models\EcTrack;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use Throwable;
+use ZipArchive;
+
+/**
+ * Applica geometrie REER (KMZ ufficiale) alle sole tracce GeoHub marcate
+ * "presente da aggiornare" nel workbook prodotto da geohub:compare-reer (foglio Tracce).
+ */
+class ApplyReerUpdatesFromWorkbookCommand extends Command
+{
+    private const STATUS_UPDATE = 'presente da aggiornare';
+
+    protected $signature = 'geohub:apply-reer-from-workbook
+        {workbook : Percorso assoluto al file .xlsx (es. export da Google Sheets)}
+        {--sheet=Tracce : Nome del foglio con colonne ID_GEOHUB, REER_CHECK, REER_KMZ}
+        {--dry-run : Elenca le righe da aggiornare senza modificare il database}
+        {--limit=0 : Elabora al massimo N tracce (0 = tutte)}
+        {--timeout=120 : Timeout HTTP in secondi per scaricare ogni KMZ}
+    ';
+
+    protected $description = 'Allinea la geometria delle tracce GeoHub al REER (KMZ) solo per righe "presente da aggiornare" nel workbook';
+
+    public function handle(): int
+    {
+        $path = (string) $this->argument('workbook');
+        $sheetName = (string) $this->option('sheet');
+        $dryRun = (bool) $this->option('dry-run');
+        $limit = max(0, (int) $this->option('limit'));
+        $timeout = max(5, (int) $this->option('timeout'));
+
+        if (! is_readable($path)) {
+            $this->error("File non leggibile: {$path}");
+            $this->warn('Export dal foglio Google: File → Scarica → Microsoft Excel (.xlsx), oppure salva il workbook generato da geohub:compare-reer.');
+
+            return 1;
+        }
+
+        $spreadsheet = IOFactory::load($path);
+        $sheet = $spreadsheet->getSheetByName($sheetName);
+        if (! $sheet) {
+            $this->error("Foglio non trovato: {$sheetName}");
+            $this->line('Fogli disponibili: '.implode(', ', $spreadsheet->getSheetNames()));
+
+            return 1;
+        }
+
+        $rows = $sheet->toArray();
+        if ($rows === []) {
+            $this->warn('Foglio vuoto.');
+
+            return 0;
+        }
+
+        $header = array_shift($rows);
+        $colIndex = $this->mapHeaderRow($header);
+        if ($colIndex['id'] === null || $colIndex['check'] === null || $colIndex['kmz'] === null) {
+            $this->error('Intestazioni attese: ID_GEOHUB, REER_CHECK, REER_KMZ (opzionale LINK_EDIT_GEOHUB). Trovato: '.json_encode($header));
+
+            return 1;
+        }
+
+        $candidates = [];
+        foreach ($rows as $idx => $row) {
+            $checkRaw = $colIndex['check'] !== null ? ($row[$colIndex['check']] ?? null) : null;
+            $checkNorm = $this->normalizeStatus($checkRaw);
+            if ($checkNorm !== self::STATUS_UPDATE) {
+                continue;
+            }
+            $idRaw = $row[$colIndex['id']] ?? null;
+            $trackId = $this->parseTrackId($idRaw);
+            if ($trackId === null) {
+                $this->warn('Riga '.($idx + 2).': ID_GEOHUB non valido, skip.');
+                continue;
+            }
+            $kmz = $colIndex['kmz'] !== null ? trim((string) ($row[$colIndex['kmz']] ?? '')) : '';
+            if ($kmz === '' || ! filter_var($kmz, FILTER_VALIDATE_URL)) {
+                $this->warn("Traccia {$trackId}: REER_KMZ assente o URL non valido, skip.");
+                continue;
+            }
+            $candidates[] = ['track_id' => $trackId, 'kmz' => $kmz];
+        }
+
+        $total = count($candidates);
+        if ($limit > 0) {
+            $candidates = array_slice($candidates, 0, $limit);
+        }
+
+        $this->info('Righe "presente da aggiornare" con KMZ valido: '.$total.' (elaboro: '.count($candidates).')');
+
+        if ($candidates === []) {
+            return 0;
+        }
+
+        if ($dryRun) {
+            foreach ($candidates as $c) {
+                $this->line("[dry-run] track_id={$c['track_id']} kmz={$c['kmz']}");
+            }
+            $this->info('Nessuna modifica (dry-run).');
+
+            return 0;
+        }
+
+        $ok = 0;
+        $fail = 0;
+        foreach ($candidates as $c) {
+            $trackId = $c['track_id'];
+            $kmzUrl = $c['kmz'];
+            try {
+                $payload = $this->fetchKmlOrRawXml($kmzUrl, $timeout);
+                if ($payload === null || $payload === '') {
+                    $this->error("Traccia {$trackId}: download KMZ/KML fallito o archivio non valido.");
+                    $fail++;
+
+                    continue;
+                }
+                $track = EcTrack::query()->find($trackId);
+                if (! $track) {
+                    $this->error("Traccia {$trackId}: non trovata.");
+                    $fail++;
+
+                    continue;
+                }
+                $geometry = $track->fileToGeometry($payload);
+                if ($geometry === null) {
+                    $this->error("Traccia {$trackId}: impossibile derivare la geometria dal file REER.");
+                    $fail++;
+
+                    continue;
+                }
+
+                EcTrack::withoutEvents(function () use ($track, $geometry) {
+                    $track->geometry = $geometry;
+                    $track->save();
+                });
+
+                $track->refresh();
+                $this->dispatchGeometryFollowUpChain($track);
+                $this->info("Traccia {$trackId}: geometria aggiornata da REER (code post-processing accodati).");
+                $ok++;
+            } catch (Throwable $e) {
+                Log::error('geohub:apply-reer-from-workbook track '.$trackId.': '.$e->getMessage(), ['e' => $e]);
+                $this->error("Traccia {$trackId}: ".$e->getMessage());
+                $fail++;
+            }
+        }
+
+        $this->info("Completato. OK={$ok}, errori={$fail}");
+
+        return $fail > 0 ? 1 : 0;
+    }
+
+    /**
+     * @param  list<mixed>  $headerRow
+     * @return array{id: int|null, check: int|null, kmz: int|null}
+     */
+    private function mapHeaderRow(array $headerRow): array
+    {
+        $norm = static function ($v): string {
+            return strtolower(trim((string) $v));
+        };
+        $map = [];
+        foreach ($headerRow as $i => $label) {
+            $map[$norm($label)] = $i;
+        }
+
+        return [
+            'id' => $map['id_geohub'] ?? null,
+            'check' => $map['reer_check'] ?? null,
+            'kmz' => $map['reer_kmz'] ?? null,
+        ];
+    }
+
+    private function normalizeStatus(mixed $value): string
+    {
+        $s = strtolower(trim((string) $value));
+
+        return match ($s) {
+            'presente da aggiornare', 'presente_da_aggiornare' => self::STATUS_UPDATE,
+            default => $s,
+        };
+    }
+
+    private function parseTrackId(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (is_numeric($value)) {
+            return (int) round((float) $value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Scarica KMZ o KML; se ZIP, estrae il primo KML utile (preferenza doc.kml).
+     */
+    private function fetchKmlOrRawXml(string $url, int $timeout): ?string
+    {
+        $response = Http::timeout($timeout)
+            ->withHeaders(['User-Agent' => 'GeoHub-REER-apply/1'])
+            ->get($url);
+        if (! $response->successful()) {
+            return null;
+        }
+        $body = $response->body();
+        $trim = ltrim($body);
+        if (str_starts_with($trim, '<?xml') || str_starts_with($trim, '<kml')) {
+            return $body;
+        }
+
+        $tmp = tempnam(sys_get_temp_dir(), 'reer_kmz_');
+        if ($tmp === false) {
+            return null;
+        }
+        file_put_contents($tmp, $body);
+        $zip = new ZipArchive;
+        if ($zip->open($tmp) !== true) {
+            @unlink($tmp);
+
+            return null;
+        }
+        $kml = false;
+        $docIdx = $zip->locateName('doc.kml');
+        if ($docIdx !== false) {
+            $kml = $zip->getFromIndex($docIdx);
+        }
+        if ($kml === false) {
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $name = $zip->getNameIndex($i);
+                if (is_string($name) && preg_match('/\\.kml$/i', $name)) {
+                    $kml = $zip->getFromIndex($i);
+                    break;
+                }
+            }
+        }
+        $zip->close();
+        @unlink($tmp);
+
+        return $kml !== false ? $kml : null;
+    }
+
+    /**
+     * Stessa catena di updateDataChain ma senza UpdateTrackFromOsmJob: la geometria REER non deve essere sovrascritta da OSM.
+     */
+    private function dispatchGeometryFollowUpChain(EcTrack $track): void
+    {
+        $chain = [];
+        $layers = $track->associatedLayers;
+        if ($layers && $layers->count() > 0) {
+            foreach ($layers as $layer) {
+                $chain[] = new UpdateLayerTracksJob($layer);
+            }
+        }
+        $chain[] = new UpdateEcTrackDemJob($track);
+        $chain[] = new UpdateManualDataJob($track);
+        $chain[] = new UpdateCurrentDataJob($track);
+        $chain[] = new UpdateEcTrack3DDemJob($track);
+        $chain[] = new UpdateEcTrackSlopeValues($track);
+        $chain[] = new UpdateModelWithGeometryTaxonomyWhere($track);
+        $chain[] = new UpdateEcTrackGenerateElevationChartImage($track);
+        $chain[] = new UpdateEcTrackAwsJob($track);
+        $chain[] = new UpdateEcTrackElasticIndexJob($track);
+        $chain[] = new UpdateTrackPBFInfoJob($track);
+        $chain[] = new GeneratePBFByTrackJob($track);
+        $chain[] = new UpdateEcTrackOrderRelatedPoi($track);
+
+        Bus::chain($chain)
+            ->catch(function (Throwable $e) {
+                Log::error($e->getMessage());
+            })->dispatch();
+    }
+}

--- a/app/Console/Commands/ApplyReerUpdatesFromWorkbookCommand.php
+++ b/app/Console/Commands/ApplyReerUpdatesFromWorkbookCommand.php
@@ -214,7 +214,7 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
                 if ($useGeojson && $c['id_percorso'] !== '') {
                     $gKey = strtolower($c['id_percorso']);
                     if (isset($geomIndex[$gKey])) {
-                        $geometry = $this->geometryRawFromGeoJson($geomIndex[$gKey]);
+                        $geometry = $this->geometryWktFromGeoJson($geomIndex[$gKey]);
                     }
                 }
 
@@ -430,12 +430,25 @@ class ApplyReerUpdatesFromWorkbookCommand extends Command
     }
 
     /**
+     * WKT per assegnazione a EcTrack::geometry: il mutatore aggiunge "SRID=4326;" e non accetta DB::raw().
+     *
      * @param  array<string, mixed>  $geometry
-     * @return \Illuminate\Database\Query\Expression
      */
-    private function geometryRawFromGeoJson(array $geometry)
+    private function geometryWktFromGeoJson(array $geometry): string
     {
-        return DB::raw("(ST_Force3D(ST_GeomFromGeoJSON('".json_encode($geometry)."')))");
+        $geomJson = json_encode($geometry);
+        if (! is_string($geomJson)) {
+            throw new RuntimeException('Impossibile serializzare geometria GeoJSON.');
+        }
+        $row = DB::selectOne(
+            'SELECT ST_AsText(ST_Force3D(ST_LineMerge(ST_SetSRID(ST_GeomFromGeoJSON(?), 4326)))) AS wkt',
+            [$geomJson]
+        );
+        if (! $row || ! isset($row->wkt) || ! is_string($row->wkt) || $row->wkt === '') {
+            throw new RuntimeException('PostGIS: geometria GeoJSON non valida o vuota.');
+        }
+
+        return $row->wkt;
     }
 
     private function parseIdPercorsoFromKmzUrl(string $url): ?string

--- a/app/Console/Commands/CompareReerCommand.php
+++ b/app/Console/Commands/CompareReerCommand.php
@@ -514,5 +514,4 @@ class CompareReerCommand extends Command
 
         file_put_contents($path, implode("\n", $lines));
     }
-
 }

--- a/app/Console/Commands/CompareReerCommand.php
+++ b/app/Console/Commands/CompareReerCommand.php
@@ -1,0 +1,518 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Console\Concerns\StreamsReerGeoJsonFeatures;
+use App\Exports\ReerMatchingWorkbookExport;
+use App\Models\App;
+use App\Models\EcTrack;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Maatwebsite\Excel\Facades\Excel;
+use Throwable;
+
+class CompareReerCommand extends Command
+{
+    use StreamsReerGeoJsonFeatures;
+
+    /**
+     * Confronto geometrico PostGIS tra tracce GeoHub e REER (GeoJSON ufficiale).
+     *
+     * Default ticket: utente pec@webmapp.it; opzionale perimetro app via layer.
+     */
+    protected $signature = 'geohub:compare-reer
+        {geojson : Path del file GeoJSON REER}
+        {--scope=user : Perimetro tracce: user (email) oppure app (layer)}
+        {--email=pec@webmapp.it : Email utente (con scope=user)}
+        {--app-id= : ID app GeoHub (con scope=app)}
+        {--dwithin-m=50 : Tolleranza ST_DWithin in metri}
+        {--hausdorff-m=20 : Soglia Hausdorff (metri) per "presente e aggiornato"}
+        {--topn=10 : Candidati REER (KNN) su cui calcolare Hausdorff}
+        {--match-chunk=40 : Tracce per batch matching (log avanzamento; batch piccoli = meno silenzio lungo)}
+        {--out-xlsx=report_reer_geohub.xlsx : Workbook Excel in storage/app}
+        {--out-csv= : (Opzionale) CSV foglio principale in storage/app}
+        {--out-md= : (Opzionale) Relazione Markdown in storage/app}
+        {--base-edit-url=https://geohub.webmapp.it : Base URL per LINK_EDIT_GEOHUB}
+    ';
+
+    protected $description = 'Confronto REER vs GeoHub (PostGIS): Excel multi-foglio + relazione matching';
+
+    public function handle(): int
+    {
+        $geojsonPath = (string) $this->argument('geojson');
+        $scope = strtolower(trim((string) $this->option('scope')));
+        $email = (string) $this->option('email');
+        $appIdOpt = $this->option('app-id');
+        $resolvedAppId = null;
+        $dwithinM = (float) $this->option('dwithin-m');
+        $hausdorffOkM = (float) $this->option('hausdorff-m');
+        $topN = max(1, (int) $this->option('topn'));
+        $matchChunk = max(5, min(500, (int) $this->option('match-chunk')));
+        $outXlsx = (string) $this->option('out-xlsx');
+        $outCsv = (string) ($this->option('out-csv') ?? '');
+        $outMd = (string) ($this->option('out-md') ?? '');
+        $baseEditUrl = rtrim((string) $this->option('base-edit-url'), '/');
+
+        if (! in_array($scope, ['user', 'app'], true)) {
+            $this->error('scope deve essere "user" oppure "app"');
+
+            return 1;
+        }
+
+        if (! file_exists($geojsonPath)) {
+            $this->error("File GeoJSON non trovato: {$geojsonPath}");
+
+            return 1;
+        }
+
+        @ini_set('memory_limit', '1024M');
+
+        $user = null;
+        if ($scope === 'user') {
+            $user = User::query()->where('email', $email)->first();
+            if (! $user) {
+                $this->error("Utente non trovato: {$email}");
+
+                return 1;
+            }
+            $this->info("Scope: utente {$email} (user_id={$user->id})");
+        } else {
+            if ($appIdOpt === null || $appIdOpt === '') {
+                $this->error('Con scope=app è obbligatorio --app-id=');
+
+                return 1;
+            }
+            $resolvedAppId = (int) $appIdOpt;
+            $app = App::with('layers')->find($resolvedAppId);
+            if (! $app) {
+                $this->error("App non trovata: {$resolvedAppId}");
+
+                return 1;
+            }
+            $this->info("Scope: app id={$resolvedAppId} ({$app->name})");
+        }
+
+        $this->info("REER GeoJSON: {$geojsonPath}");
+
+        DB::disableQueryLog();
+        $conn = DB::connection();
+
+        $csvFp = null;
+        $csvOutPath = null;
+        if (is_string($outCsv) && trim($outCsv) !== '') {
+            $csvOutPath = storage_path('app/'.ltrim(trim($outCsv), '/'));
+            $csvFp = fopen($csvOutPath, 'wb');
+            if (! $csvFp) {
+                $this->error("Impossibile creare CSV: {$csvOutPath}");
+
+                return 1;
+            }
+            fputcsv($csvFp, ['ID_GEOHUB', 'LINK_EDIT_GEOHUB', 'REER_CHECK', 'REER_KMZ']);
+        }
+
+        try {
+            $conn->beginTransaction();
+
+            $this->info('Creo tabella temporanea e carico geometrie REER in PostGIS...');
+            $conn->statement('DROP TABLE IF EXISTS tmp_reer_features');
+            $conn->statement('
+                CREATE TEMP TABLE tmp_reer_features (
+                    id serial PRIMARY KEY,
+                    id_percorso text,
+                    download_kmz text,
+                    geom geometry(MultiLineString, 4326)
+                )
+            ');
+
+            $inserted = 0;
+            foreach ($this->streamReerGeoJsonFeatures($geojsonPath) as $feature) {
+                $props = $feature['properties'] ?? null;
+                $geom = $feature['geometry'] ?? null;
+                if (! is_array($props) || ! is_array($geom)) {
+                    continue;
+                }
+
+                $idPercorso = $props['ID_PERCORSO'] ?? null;
+                $downloadKmz = $props['DOWNLOAD_KMZ'] ?? null;
+                $geomJson = json_encode($geom);
+                if (! is_string($geomJson)) {
+                    continue;
+                }
+
+                $conn->insert(
+                    'INSERT INTO tmp_reer_features (id_percorso, download_kmz, geom)
+                     VALUES (?, ?, ST_SetSRID(ST_GeomFromGeoJSON(?), 4326))',
+                    [
+                        (is_string($idPercorso) && trim($idPercorso) !== '') ? trim($idPercorso) : null,
+                        (is_string($downloadKmz) && trim($downloadKmz) !== '') ? trim($downloadKmz) : null,
+                        $geomJson,
+                    ]
+                );
+                $inserted++;
+
+                if ($inserted % 1000 === 0) {
+                    $this->info(" - Caricate {$inserted} features REER...");
+                }
+            }
+            $this->info("Features REER caricate in PostGIS: {$inserted}");
+
+            if ($scope === 'user') {
+                $this->info('Recupero tracce GEOHUB per user_id...');
+                $trackIds = EcTrack::query()
+                    ->where('user_id', $user->id)
+                    ->whereNotNull('geometry')
+                    ->orderBy('id')
+                    ->pluck('id')
+                    ->all();
+            } else {
+                $this->info('Recupero tracce GEOHUB dai layer dell\'app...');
+                $trackIds = array_keys($app->getTracksFromLayer());
+                sort($trackIds);
+                $trackIds = array_values(array_filter($trackIds, static fn ($id) => $id !== null && $id !== ''));
+                $trackIds = EcTrack::query()
+                    ->whereIn('id', $trackIds)
+                    ->whereNotNull('geometry')
+                    ->orderBy('id')
+                    ->pluck('id')
+                    ->all();
+            }
+
+            $totalTracks = count($trackIds);
+            $this->info("Tracce GeoHub con geometria: {$totalTracks}");
+
+            if ($totalTracks === 0) {
+                $this->warn('Nessuna traccia GeoHub nel perimetro: workbook con solo REER e riepilogo.');
+                $reerUnmatched = $conn->select('
+                    SELECT COALESCE(id_percorso, id::text) AS id_percorso, download_kmz
+                    FROM tmp_reer_features
+                    ORDER BY id
+                ');
+                $reerSenzaGeohubRows = [];
+                foreach ($reerUnmatched as $u) {
+                    $reerSenzaGeohubRows[] = [
+                        (string) $u->id_percorso,
+                        is_string($u->download_kmz ?? null) ? (string) $u->download_kmz : '',
+                    ];
+                }
+                $summaryRows = [
+                    ['Data', now()->toIso8601String()],
+                    ['Scope', $scope],
+                    ['Email', $scope === 'user' ? $email : '—'],
+                    ['App ID', $resolvedAppId !== null ? (string) $resolvedAppId : '—'],
+                    ['GeoJSON REER', $geojsonPath],
+                    ['Features REER caricate', (string) $inserted],
+                    ['Tracce GeoHub confrontate', '0'],
+                    ['dwithin_m', (string) $dwithinM],
+                    ['hausdorff_ok_m', (string) $hausdorffOkM],
+                    ['topn', (string) $topN],
+                    ['Nota', 'Nessuna traccia con geometria nel perimetro scelto'],
+                ];
+                $conn->commit();
+                if ($csvFp) {
+                    fclose($csvFp);
+                }
+                $xlsxRelPath = ltrim($outXlsx, '/');
+                Excel::store(
+                    new ReerMatchingWorkbookExport(
+                        [],
+                        $summaryRows,
+                        [],
+                        $reerSenzaGeohubRows,
+                        []
+                    ),
+                    $xlsxRelPath,
+                    'local'
+                );
+                $this->info('Excel generato: '.storage_path('app/'.$xlsxRelPath));
+                if (trim($outMd) !== '') {
+                    $mdPath = storage_path('app/'.ltrim(trim($outMd), '/'));
+                    $this->writeMarkdownReport($mdPath, $summaryRows, [], $reerSenzaGeohubRows, []);
+                    $this->info("Markdown: {$mdPath}");
+                }
+                $this->info('Done.');
+
+                return 0;
+            }
+
+            $conn->statement('DROP TABLE IF EXISTS tmp_geohub_tracks');
+            $conn->statement('
+                CREATE TEMP TABLE tmp_geohub_tracks (
+                    track_id bigint PRIMARY KEY,
+                    geom_3857 geometry(LineString, 3857)
+                )
+            ');
+
+            foreach (array_chunk($trackIds, 1000) as $chunk) {
+                $ids = implode(',', array_map('intval', $chunk));
+                $conn->statement("
+                    INSERT INTO tmp_geohub_tracks (track_id, geom_3857)
+                    SELECT
+                        id AS track_id,
+                        ST_Transform(ST_Force2D(ST_SetSRID(geometry, 4326)), 3857) AS geom_3857
+                    FROM ec_tracks
+                    WHERE id IN ({$ids})
+                ");
+            }
+
+            $conn->statement('CREATE INDEX tmp_geohub_tracks_geom_gix ON tmp_geohub_tracks USING GIST (geom_3857)');
+            $conn->statement('ANALYZE tmp_geohub_tracks');
+
+            $conn->statement('DROP TABLE IF EXISTS tmp_reer_features_3857');
+            $conn->statement('
+                CREATE TEMP TABLE tmp_reer_features_3857 AS
+                SELECT
+                    id,
+                    id_percorso,
+                    download_kmz,
+                    ST_Transform(ST_Force2D(geom), 3857) AS geom_3857
+                FROM tmp_reer_features
+            ');
+
+            $conn->statement('CREATE INDEX tmp_reer_features_3857_geom_gix ON tmp_reer_features_3857 USING GIST (geom_3857)');
+            $conn->statement('ANALYZE tmp_reer_features_3857');
+
+            $this->info('Matching spaziale (ST_DWithin + Hausdorff su top candidati), batch da '.$matchChunk.' tracce...');
+            $result = [];
+            $processed = 0;
+            foreach (array_chunk($trackIds, $matchChunk) as $chunk) {
+                $idsSql = implode(',', array_map('intval', $chunk));
+                $batch = $conn->select("
+                    SELECT
+                        t.track_id,
+                        b.reer_id,
+                        b.id_percorso,
+                        b.download_kmz,
+                        b.hausdorff_m
+                    FROM tmp_geohub_tracks t
+                    LEFT JOIN LATERAL (
+                        SELECT reer_id, id_percorso, download_kmz, hausdorff_m
+                        FROM (
+                            SELECT
+                                r.id AS reer_id,
+                                r.id_percorso,
+                                r.download_kmz,
+                                ST_HausdorffDistance(t.geom_3857, r.geom_3857) AS hausdorff_m
+                            FROM tmp_reer_features_3857 r
+                            WHERE ST_DWithin(t.geom_3857, r.geom_3857, {$dwithinM})
+                            ORDER BY t.geom_3857 <-> r.geom_3857
+                            LIMIT {$topN}
+                        ) c
+                        ORDER BY hausdorff_m ASC
+                        LIMIT 1
+                    ) b ON TRUE
+                    WHERE t.track_id IN ({$idsSql})
+                    ORDER BY t.track_id
+                ");
+                foreach ($batch as $row) {
+                    $result[] = $row;
+                }
+                $processed += count($chunk);
+                $this->line(" - Hausdorff: tracce {$processed}/{$totalTracks}");
+            }
+
+            $this->info('Rilevo match ambigui (più candidati entro buffer)...');
+            $ambigui = [];
+            $ambigProcessed = 0;
+            foreach (array_chunk($trackIds, $matchChunk) as $chunk) {
+                $idsSql = implode(',', array_map('intval', $chunk));
+                $batch = $conn->select("
+                    SELECT t.track_id, COUNT(*)::int AS candidati
+                    FROM tmp_geohub_tracks t
+                    INNER JOIN tmp_reer_features_3857 r ON ST_DWithin(t.geom_3857, r.geom_3857, {$dwithinM})
+                    WHERE t.track_id IN ({$idsSql})
+                    GROUP BY t.track_id
+                    HAVING COUNT(*) > 1
+                    ORDER BY candidati DESC, t.track_id
+                ");
+                foreach ($batch as $a) {
+                    $ambigui[] = $a;
+                }
+                $ambigProcessed += count($chunk);
+                $this->line(" - Ambigui: tracce {$ambigProcessed}/{$totalTracks}");
+            }
+
+            $mainRows = [];
+            $matchedReerInternalIds = [];
+            $counts = [
+                'presente e aggiornato' => 0,
+                'assente' => 0,
+                'presente da aggiornare' => 0,
+            ];
+
+            foreach ($result as $row) {
+                $trackId = (int) $row->track_id;
+                $linkEdit = "{$baseEditUrl}/resources/ec-tracks/{$trackId}/edit";
+
+                $status = 'assente';
+                $kmz = '';
+                if (isset($row->hausdorff_m) && $row->hausdorff_m !== null) {
+                    $hausdorff = (float) $row->hausdorff_m;
+                    $status = $hausdorff <= $hausdorffOkM ? 'presente e aggiornato' : 'presente da aggiornare';
+                    $kmz = is_string($row->download_kmz ?? null) ? (string) $row->download_kmz : '';
+                    if (isset($row->reer_id) && $row->reer_id !== null) {
+                        $matchedReerInternalIds[(int) $row->reer_id] = true;
+                    }
+                }
+
+                $counts[$status]++;
+                $mainRows[] = [$trackId, $linkEdit, $status, $kmz];
+
+                if ($csvFp) {
+                    fputcsv($csvFp, [$trackId, $linkEdit, $status, $kmz]);
+                }
+            }
+
+            $matchedIdsList = array_keys($matchedReerInternalIds);
+            $placeholders = count($matchedIdsList) > 0 ? implode(',', array_map('intval', $matchedIdsList)) : '0';
+
+            $reerUnmatched = $conn->select("
+                SELECT
+                    COALESCE(id_percorso, id::text) AS id_percorso,
+                    download_kmz
+                FROM tmp_reer_features
+                WHERE id NOT IN ({$placeholders})
+                ORDER BY id
+            ");
+
+            $geohubSenzaReer = [];
+            foreach ($mainRows as $r) {
+                if ($r[2] === 'assente') {
+                    $geohubSenzaReer[] = [$r[0], $r[1]];
+                }
+            }
+
+            $ambiguiRows = [];
+            foreach ($ambigui as $a) {
+                $tid = (int) $a->track_id;
+                $ambiguiRows[] = [
+                    $tid,
+                    "{$baseEditUrl}/resources/ec-tracks/{$tid}/edit",
+                    (int) $a->candidati,
+                ];
+            }
+
+            $reerSenzaGeohubRows = [];
+            foreach ($reerUnmatched as $u) {
+                $reerSenzaGeohubRows[] = [
+                    (string) $u->id_percorso,
+                    is_string($u->download_kmz ?? null) ? (string) $u->download_kmz : '',
+                ];
+            }
+
+            $conn->commit();
+
+            if ($csvFp) {
+                fclose($csvFp);
+                $this->info("CSV generato: {$csvOutPath}");
+            }
+
+            $summaryRows = [
+                ['Data', now()->toIso8601String()],
+                ['Scope', $scope],
+                ['Email', $scope === 'user' ? $email : '—'],
+                ['App ID', $resolvedAppId !== null ? (string) $resolvedAppId : '—'],
+                ['GeoJSON REER', $geojsonPath],
+                ['Features REER caricate', (string) $inserted],
+                ['Tracce GeoHub confrontate', (string) $totalTracks],
+                ['dwithin_m', (string) $dwithinM],
+                ['hausdorff_ok_m', (string) $hausdorffOkM],
+                ['topn', (string) $topN],
+                ['presente e aggiornato', (string) $counts['presente e aggiornato']],
+                ['assente', (string) $counts['assente']],
+                ['presente da aggiornare', (string) $counts['presente da aggiornare']],
+                ['REER non abbinate a nessuna traccia', (string) count($reerSenzaGeohubRows)],
+                ['Tracce con più candidati nel buffer', (string) count($ambiguiRows)],
+            ];
+
+            $xlsxRelPath = ltrim($outXlsx, '/');
+            $this->info('Genero workbook Excel...');
+            Excel::store(
+                new ReerMatchingWorkbookExport(
+                    $mainRows,
+                    $summaryRows,
+                    $geohubSenzaReer,
+                    $reerSenzaGeohubRows,
+                    $ambiguiRows
+                ),
+                $xlsxRelPath,
+                'local'
+            );
+            $this->info('Excel generato: '.storage_path('app/'.$xlsxRelPath));
+
+            if (trim($outMd) !== '') {
+                $mdPath = storage_path('app/'.ltrim(trim($outMd), '/'));
+                $this->writeMarkdownReport(
+                    $mdPath,
+                    $summaryRows,
+                    $geohubSenzaReer,
+                    $reerSenzaGeohubRows,
+                    $ambiguiRows
+                );
+                $this->info("Markdown: {$mdPath}");
+            }
+
+            $this->info('Done.');
+
+            return 0;
+        } catch (Throwable $e) {
+            try {
+                if ($conn->transactionLevel() > 0) {
+                    $conn->rollBack();
+                }
+            } catch (Throwable $ignored) {
+            }
+            if ($csvFp) {
+                fclose($csvFp);
+            }
+            $this->error($e->getMessage());
+
+            return 1;
+        }
+    }
+
+    /**
+     * @param  array<int, array{0: string, 1: string|int|float}>  $summaryRows
+     * @param  array<int, array<int, mixed>>  $geohubSenzaReer
+     * @param  array<int, array<int, mixed>>  $reerSenzaGeohub
+     * @param  array<int, array<int, mixed>>  $ambigui
+     */
+    private function writeMarkdownReport(
+        string $path,
+        array $summaryRows,
+        array $geohubSenzaReer,
+        array $reerSenzaGeohub,
+        array $ambigui
+    ): void {
+        $dir = dirname($path);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $lines = [
+            '# Relazione matching GeoHub vs REER',
+            '',
+            '## Parametri e conteggi',
+            '',
+        ];
+        foreach ($summaryRows as [$k, $v]) {
+            $lines[] = '- **'.$k.'**: '.$v;
+        }
+        $lines[] = '';
+        $lines[] = '## GeoHub senza corrispondenza REER (assenti)';
+        $lines[] = '';
+        $lines[] = 'Totale righe: '.count($geohubSenzaReer);
+        $lines[] = '';
+        $lines[] = '## REER senza traccia GeoHub nel perimetro scelto';
+        $lines[] = '';
+        $lines[] = 'Totale righe: '.count($reerSenzaGeohub);
+        $lines[] = '';
+        $lines[] = '## Match potenzialmente ambigui (più geometrie REER nel buffer)';
+        $lines[] = '';
+        $lines[] = 'Totale tracce: '.count($ambigui);
+        $lines[] = '';
+
+        file_put_contents($path, implode("\n", $lines));
+    }
+
+}

--- a/app/Console/Commands/ExportReerWorkbookPostApplyCommand.php
+++ b/app/Console/Commands/ExportReerWorkbookPostApplyCommand.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Console\Command;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Throwable;
 
 /**
@@ -79,7 +80,7 @@ class ExportReerWorkbookPostApplyCommand extends Command
         return base_path($path);
     }
 
-    private function updateTracksSheet(\PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet): int
+    private function updateTracksSheet(Worksheet $sheet): int
     {
         $rows = $sheet->toArray();
         if ($rows === []) {

--- a/app/Console/Commands/ExportReerWorkbookPostApplyCommand.php
+++ b/app/Console/Commands/ExportReerWorkbookPostApplyCommand.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use Throwable;
+
+/**
+ * Dopo geohub:apply-reer-from-workbook: aggiorna lo stesso workbook
+ * marcando come "presente e aggiornato" le tracce che erano "presente da aggiornare"
+ * e ricalcola i conteggi nel foglio Riepilogo.
+ */
+class ExportReerWorkbookPostApplyCommand extends Command
+{
+    private const SHEET_TRACKS = 'Tracce';
+
+    private const SHEET_SUMMARY = 'Riepilogo';
+
+    private const COL_STATUS_OLD = 'presente da aggiornare';
+
+    private const COL_STATUS_NEW = 'presente e aggiornato';
+
+    protected $signature = 'geohub:export-reer-workbook-post-apply
+        {input : Percorso al .xlsx originale del confronto (es. storage/app/reer_report_workbook.xlsx)}
+        {--output= : Percorso di uscita (default: storage/app/reer_report_post_apply_<data>.xlsx)}
+        {--sheet=Tracce : Foglio delle tracce}
+    ';
+
+    protected $description = 'Produce una copia Excel del confronto REER con REER_CHECK aggiornato dopo l\'apply su GeoHub';
+
+    public function handle(): int
+    {
+        $in = $this->resolvePath((string) $this->argument('input'));
+        $sheetName = (string) $this->option('sheet');
+        $defaultOut = storage_path('app/reer_report_post_apply_'.Carbon::now()->format('Ymd_His').'.xlsx');
+        $out = $this->option('output') ? $this->resolvePath((string) $this->option('output')) : $defaultOut;
+
+        if (! is_readable($in)) {
+            $this->error("File non leggibile: {$in}");
+
+            return 1;
+        }
+
+        try {
+            $spreadsheet = IOFactory::load($in);
+            $sheet = $spreadsheet->getSheetByName($sheetName);
+            if (! $sheet) {
+                $this->error("Foglio non trovato: {$sheetName}");
+
+                return 1;
+            }
+
+            $changed = $this->updateTracksSheet($sheet);
+            $this->updateSummarySheet($spreadsheet, $changed);
+
+            $writer = IOFactory::createWriter($spreadsheet, 'Xlsx');
+            $writer->save($out);
+
+            $this->info("Aggiornate {$changed} righe nel foglio \"{$sheetName}\".");
+            $this->info('File salvato: '.$out);
+        } catch (Throwable $e) {
+            $this->error($e->getMessage());
+
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private function resolvePath(string $path): string
+    {
+        if ($path !== '' && $path[0] === DIRECTORY_SEPARATOR) {
+            return $path;
+        }
+
+        return base_path($path);
+    }
+
+    private function updateTracksSheet(\PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet): int
+    {
+        $rows = $sheet->toArray();
+        if ($rows === []) {
+            return 0;
+        }
+        $header = array_shift($rows);
+        $colCheck = null;
+        foreach ($header as $i => $label) {
+            if (strtolower(trim((string) $label)) === 'reer_check') {
+                $colCheck = (int) $i;
+                break;
+            }
+        }
+        if ($colCheck === null) {
+            throw new \RuntimeException('Colonna REER_CHECK non trovata nel foglio tracce.');
+        }
+
+        $changed = 0;
+        foreach ($rows as $idx => $row) {
+            $raw = isset($row[$colCheck]) ? trim((string) $row[$colCheck]) : '';
+            $norm = preg_replace('/[\s_-]+/u', ' ', strtolower($raw));
+            if ($norm !== self::COL_STATUS_OLD) {
+                continue;
+            }
+            $sheet->setCellValueByColumnAndRow($colCheck + 1, $idx + 2, self::COL_STATUS_NEW);
+            $changed++;
+        }
+
+        return $changed;
+    }
+
+    private function updateSummarySheet(Spreadsheet $spreadsheet, int $changed): void
+    {
+        $summary = $spreadsheet->getSheetByName(self::SHEET_SUMMARY);
+        if (! $summary || $changed <= 0) {
+            return;
+        }
+
+        $dataRow = Carbon::now()->timezone(config('app.timezone'))->toIso8601String();
+        $rows = $summary->toArray();
+        foreach ($rows as $rowIdx => $row) {
+            $key = isset($row[0]) ? trim((string) $row[0]) : '';
+            if ($key === 'Data') {
+                $summary->setCellValueByColumnAndRow(2, $rowIdx + 1, $dataRow);
+            }
+            if ($key === 'presente e aggiornato') {
+                $prev = isset($row[1]) ? (int) $row[1] : 0;
+                $summary->setCellValueByColumnAndRow(2, $rowIdx + 1, $prev + $changed);
+            }
+            if ($key === 'presente da aggiornare') {
+                $prev = isset($row[1]) ? (int) $row[1] : 0;
+                $summary->setCellValueByColumnAndRow(2, $rowIdx + 1, max(0, $prev - $changed));
+            }
+        }
+    }
+}

--- a/app/Console/Commands/SyncReerFromGeojsonCommand.php
+++ b/app/Console/Commands/SyncReerFromGeojsonCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+
+/**
+ * Esegue geohub:compare-reer e, se richiesto, geohub:apply-reer-from-workbook
+ * sul workbook appena generato (solo righe "presente da aggiornare").
+ */
+class SyncReerFromGeojsonCommand extends Command
+{
+    protected $signature = 'geohub:sync-reer-from-geojson
+        {geojson : Percorso al GeoJSON REER (come in compare-reer)}
+        {--scope=user : Perimetro tracce: user | app}
+        {--email=pec@webmapp.it : Email utente (con scope=user)}
+        {--app-id= : ID app GeoHub (con scope=app)}
+        {--dwithin-m=50 : Tolleranza ST_DWithin in metri}
+        {--hausdorff-m=20 : Soglia Hausdorff per "presente e aggiornato"}
+        {--topn=10 : Candidati REER (KNN) per Hausdorff}
+        {--match-chunk=40 : Tracce per batch nel matching}
+        {--out-xlsx=report_reer_geohub.xlsx : Workbook in storage/app}
+        {--out-csv= : Opzionale CSV in storage/app}
+        {--out-md= : Opzionale Markdown in storage/app}
+        {--base-edit-url=https://geohub.webmapp.it : Base URL LINK_EDIT_GEOHUB}
+        {--sheet=Tracce : Foglio tracce nel workbook}
+        {--compare-only : Solo confronto (nessun aggiornamento DB)}
+        {--dry-run : Dopo il confronto, elenca l\'apply senza modificare il DB}
+        {--limit=0 : Max tracce da aggiornare (0 = tutte)}
+        {--timeout=120 : Timeout HTTP per KMZ se manca geometria nel GeoJSON}
+        {--post-apply-output= : Workbook post-apply (default con timestamp)}
+        {--no-post-export : Non scrivere Excel post-apply}
+    ';
+
+    protected $description = 'Confronto REER (GeoJSON) vs GeoHub, poi aggiorna le tracce "presente da aggiornare"';
+
+    public function handle(): int
+    {
+        $geojsonPath = $this->resolvePath((string) $this->argument('geojson'));
+        if (! is_readable($geojsonPath)) {
+            $this->error("File GeoJSON non leggibile: {$geojsonPath}");
+
+            return 1;
+        }
+
+        $compareParams = [
+            'geojson' => $geojsonPath,
+            '--scope' => (string) $this->option('scope'),
+            '--email' => (string) $this->option('email'),
+            '--dwithin-m' => (string) $this->option('dwithin-m'),
+            '--hausdorff-m' => (string) $this->option('hausdorff-m'),
+            '--topn' => (string) $this->option('topn'),
+            '--match-chunk' => (string) $this->option('match-chunk'),
+            '--out-xlsx' => (string) $this->option('out-xlsx'),
+            '--base-edit-url' => rtrim((string) $this->option('base-edit-url'), '/'),
+        ];
+        $appId = $this->option('app-id');
+        if ($appId !== null && (string) $appId !== '') {
+            $compareParams['--app-id'] = (string) $appId;
+        }
+        $outCsv = trim((string) $this->option('out-csv'));
+        if ($outCsv !== '') {
+            $compareParams['--out-csv'] = $outCsv;
+        }
+        $outMd = trim((string) $this->option('out-md'));
+        if ($outMd !== '') {
+            $compareParams['--out-md'] = $outMd;
+        }
+
+        $this->info('=== Passo 1/2: confronto REER vs GeoHub ===');
+        $compareExit = Artisan::call('geohub:compare-reer', $compareParams, $this->output);
+        if ($compareExit !== 0) {
+            $this->error('Confronto fallito: interrompo (nessun aggiornamento).');
+
+            return $compareExit;
+        }
+
+        if ((bool) $this->option('compare-only')) {
+            $this->info('=== --compare-only: confronto completato, skip apply ===');
+
+            return 0;
+        }
+
+        $workbookRel = ltrim((string) $this->option('out-xlsx'), '/');
+        $workbookAbs = storage_path('app/'.$workbookRel);
+
+        if (! is_readable($workbookAbs)) {
+            $this->error("Workbook non trovato dopo il confronto: {$workbookAbs}");
+
+            return 1;
+        }
+
+        $applyParams = [
+            'workbook' => $workbookAbs,
+            '--geojson' => $geojsonPath,
+            '--sheet' => (string) $this->option('sheet'),
+            '--limit' => (string) $this->option('limit'),
+            '--timeout' => (string) $this->option('timeout'),
+        ];
+        if ((bool) $this->option('dry-run')) {
+            $applyParams['--dry-run'] = true;
+        }
+        if ((bool) $this->option('no-post-export')) {
+            $applyParams['--no-post-export'] = true;
+        }
+        $postOut = $this->option('post-apply-output');
+        if (is_string($postOut) && $postOut !== '') {
+            $applyParams['--post-apply-output'] = $this->resolvePath($postOut);
+        }
+
+        $this->info('=== Passo 2/2: aggiorna tracce "presente da aggiornare" (GeoJSON + workbook) ===');
+        $applyExit = Artisan::call('geohub:apply-reer-from-workbook', $applyParams, $this->output);
+
+        return $applyExit;
+    }
+
+    private function resolvePath(string $path): string
+    {
+        if ($path !== '' && $path[0] === DIRECTORY_SEPARATOR) {
+            return $path;
+        }
+
+        return base_path($path);
+    }
+}

--- a/app/Console/Concerns/StreamsReerGeoJsonFeatures.php
+++ b/app/Console/Concerns/StreamsReerGeoJsonFeatures.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Console\Concerns;
+
+use Generator;
+
+trait StreamsReerGeoJsonFeatures
+{
+    /**
+     * Legge un FeatureCollection REER grande senza json_decode sull’intero file.
+     *
+     * @return Generator<int, array<string, mixed>>
+     */
+    protected function streamReerGeoJsonFeatures(string $path): Generator
+    {
+        $fp = fopen($path, 'rb');
+        if (! $fp) {
+            throw new \RuntimeException("Impossibile aprire il file: {$path}");
+        }
+
+        $buffer = '';
+        $inFeaturesArray = false;
+        $inString = false;
+        $escape = false;
+        $depth = 0;
+        $collecting = false;
+        $obj = '';
+
+        while (! feof($fp)) {
+            $chunk = fread($fp, 1024 * 1024);
+            if ($chunk === false) {
+                break;
+            }
+            $buffer .= $chunk;
+
+            $len = strlen($buffer);
+            for ($i = 0; $i < $len; $i++) {
+                $ch = $buffer[$i];
+
+                if (! $inFeaturesArray) {
+                    if (substr($buffer, $i, 10) === '"features"') {
+                        $posBracket = strpos($buffer, '[', $i);
+                        if ($posBracket !== false) {
+                            $inFeaturesArray = true;
+                            $i = $posBracket;
+                        }
+                    }
+
+                    continue;
+                }
+
+                if ($collecting) {
+                    $obj .= $ch;
+                }
+
+                if ($escape) {
+                    $escape = false;
+
+                    continue;
+                }
+                if ($ch === '\\') {
+                    if ($inString) {
+                        $escape = true;
+                    }
+
+                    continue;
+                }
+                if ($ch === '"') {
+                    $inString = ! $inString;
+
+                    continue;
+                }
+                if ($inString) {
+                    continue;
+                }
+
+                if (! $collecting) {
+                    if ($ch === '{') {
+                        $collecting = true;
+                        $depth = 1;
+                        $obj = '{';
+                    } elseif ($ch === ']') {
+                        fclose($fp);
+
+                        return;
+                    }
+
+                    continue;
+                }
+
+                if ($ch === '{') {
+                    $depth++;
+                } elseif ($ch === '}') {
+                    $depth--;
+                    if ($depth === 0) {
+                        $feature = json_decode($obj, true);
+                        if (is_array($feature)) {
+                            yield $feature;
+                        }
+                        $collecting = false;
+                        $obj = '';
+                    }
+                }
+            }
+
+            $buffer = $collecting ? '' : substr($buffer, max(0, $len - 1024));
+        }
+
+        fclose($fp);
+    }
+}

--- a/app/Jobs/UpdateEcTrackElasticIndexJob.php
+++ b/app/Jobs/UpdateEcTrackElasticIndexJob.php
@@ -2,7 +2,6 @@
 
 namespace App\Jobs;
 
-use App\Jobs\DeleteEcTrackElasticIndexJob;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;

--- a/app/Nova/EcTrack.php
+++ b/app/Nova/EcTrack.php
@@ -106,7 +106,7 @@ class EcTrack extends Resource
         if (! $model || ! $model->exists) {
             return false;
         }
-        
+
         return $model->associatedLayers()->where('app_id', 32)->exists();
     }
 

--- a/database/migrations/2026_04_08_000001_add_draft_to_ec_tracks_table.php
+++ b/database/migrations/2026_04_08_000001_add_draft_to_ec_tracks_table.php
@@ -26,4 +26,3 @@ return new class extends Migration
         });
     }
 };
-

--- a/tests/Feature/DraftExclusionPbfAndIndexTest.php
+++ b/tests/Feature/DraftExclusionPbfAndIndexTest.php
@@ -123,4 +123,3 @@ class DraftExclusionPbfAndIndexTest extends TestCase
         $this->assertEquals([188, 236], $indexed['layerIds']);
     }
 }
-


### PR DESCRIPTION
- Implemented `StreamsReerGeoJsonFeatures` trait for efficient GeoJSON feature streaming.
- Updated `ApplyReerUpdatesFromWorkbookCommand` to handle GeoJSON input and enhance workbook post-apply reporting.
- Enhanced `CompareReerCommand` for batch processing with adjustable chunk sizes, improving performance on large datasets.
- Added `ExportReerWorkbookPostApplyCommand` for exporting updated workbook reports post-apply.
- Introduced `SyncReerFromGeojsonCommand` to automate GeoJSON comparison and subsequent updates to GeoHub tracks, supporting dry-run and export options.
- Refined logic to accommodate legacy workbook formats and ensure robust path resolution.
